### PR TITLE
fix(statusline): handle null nested objects in statusline payload

### DIFF
--- a/src/agentpulse/platforms/claude/hooks.py
+++ b/src/agentpulse/platforms/claude/hooks.py
@@ -147,10 +147,10 @@ async def receive_statusline(body: dict) -> dict:
     if not session_id:
         return {"status": "ignored", "reason": "no session_id"}
 
-    cost = body.get("cost", {})
-    ctx = body.get("context_window", {})
-    current_usage = ctx.get("current_usage", {})
-    model = body.get("model", {})
+    cost = body.get("cost") or {}
+    ctx = body.get("context_window") or {}
+    current_usage = ctx.get("current_usage") or {}
+    model = body.get("model") or {}
 
     cost_usd = cost.get("total_cost_usd")
     total_input_tokens = ctx.get("total_input_tokens")


### PR DESCRIPTION
dict.get("key", {}) returns None when the key is present with a null
value, not the default {}. Use `or {}` to coalesce both missing and
null cases, preventing AttributeError on .get() calls downstream.

Assisted-by: Claude Code (Claude Opus 4.6)
