### PR TITLE
fix(hooks): resurrect ended sessions on statusline and hook events

### DIFF
--- a/src/agentpulse/platforms/claude/hooks.py
+++ b/src/agentpulse/platforms/claude/hooks.py
@@ -101,6 +101,10 @@ async def receive_hook(payload: ClaudeHookPayload) -> dict:
     )
 
     existing = await schema.get_session(db, session_id=payload.session_id)
+    is_new = existing is None
+    is_resumed = existing is not None and (
+        existing.get("ended_at") is not None or not existing.get("pid_alive", True)
+    )
 
     entrypoint = await asyncio.to_thread(detect_entrypoint, pid=payload.pid)
 
@@ -117,13 +121,21 @@ async def receive_hook(payload: ClaudeHookPayload) -> dict:
         source_system=payload.source_system,
     )
 
-    if existing is None:
-        logger.info(
-            "new session from hook session=%s pid=%d cwd=%s",
-            payload.session_id,
-            payload.pid,
-            payload.cwd,
-        )
+    if is_new or is_resumed:
+        if is_new:
+            logger.info(
+                "new session from hook session=%s pid=%d cwd=%s",
+                payload.session_id,
+                payload.pid,
+                payload.cwd,
+            )
+        else:
+            logger.info(
+                "session resumed from hook session=%s pid=%d cwd=%s",
+                payload.session_id,
+                payload.pid,
+                payload.cwd,
+            )
         await manager.broadcast(
             {
                 "type": "session_discovered",
@@ -182,7 +194,12 @@ async def receive_statusline(body: dict) -> dict:
     source_system = body.get("source_system", "")
 
     existing = await schema.get_session(db, session_id=session_id)
-    if existing is None:
+    is_new = existing is None
+    is_resumed = existing is not None and (
+        existing.get("ended_at") is not None or not existing.get("pid_alive", True)
+    )
+
+    if is_new or is_resumed:
         entrypoint = "cli"
         if pid:
             entrypoint = await asyncio.to_thread(detect_entrypoint, pid=pid)
@@ -195,11 +212,18 @@ async def receive_statusline(body: dict) -> dict:
             started_at=int(received_at * 1000),
             source_system=source_system,
         )
-        logger.info(
-            "new session from statusline session=%s cwd=%s",
-            session_id,
-            cwd,
-        )
+        if is_new:
+            logger.info(
+                "new session from statusline session=%s cwd=%s",
+                session_id,
+                cwd,
+            )
+        else:
+            logger.info(
+                "session resumed from statusline session=%s cwd=%s",
+                session_id,
+                cwd,
+            )
         await manager.broadcast(
             {
                 "type": "session_discovered",

--- a/tests/test_statusline_endpoint.py
+++ b/tests/test_statusline_endpoint.py
@@ -233,6 +233,27 @@ class TestStatuslineSessionDiscovery:
         assert row is not None
         assert row["cwd"] == "/fallback/path"
 
+    def test_resurrects_ended_session(self, client, db) -> None:
+        client.post("/statusline/claude", json=_SAMPLE_STATUSLINE)
+        run_async(schema.end_session(db, session_id="s1", ended_at=1.0))
+        run_async(schema.update_session_pid_alive(db, session_id="s1", pid_alive=False))
+
+        row = run_async(schema.get_session(db, session_id="s1"))
+        assert row["ended_at"] is not None
+        assert row["pid_alive"] == 0
+
+        with patch("agentpulse.platforms.claude.hooks.manager.broadcast") as mock_bc:
+            client.post("/statusline/claude", json=_SAMPLE_STATUSLINE)
+
+        row = run_async(schema.get_session(db, session_id="s1"))
+        assert row["ended_at"] is None
+        assert row["pid_alive"] == 1
+
+        calls = [c.args[0] for c in mock_bc.call_args_list]
+        discovered = [c for c in calls if c["type"] == "session_discovered"]
+        assert len(discovered) == 1
+        assert discovered[0]["session_id"] == "s1"
+
     def test_statusline_with_injected_pid_and_source(self, client, db) -> None:
         data = {
             **_SAMPLE_STATUSLINE,


### PR DESCRIPTION
Both receive_hook and receive_statusline now detect when an existing
session is in ended state (ended_at set or pid_alive false) and call
upsert_session to reset pid_alive=1 and ended_at=NULL. Previously
statusline only called upsert_session for brand-new sessions, so
continued/resumed sessions stayed in ended state indefinitely.

Assisted-by: Claude Code (Claude Opus 4.6)
