### PR TITLE
fix: prevent ended_at from being cleared after SessionEnd

### DIFF
--- a/src/agentpulse/platforms/claude/hooks.py
+++ b/src/agentpulse/platforms/claude/hooks.py
@@ -79,8 +79,12 @@ async def receive_hook(payload: ClaudeHookPayload) -> dict:
 
     existing = await schema.get_session(db, session_id=payload.session_id)
     is_new = existing is None
-    is_resumed = existing is not None and (
-        existing.get("ended_at") is not None or not existing.get("pid_alive", True)
+    is_resumed = (
+        existing is not None
+        and event != "SessionEnd"
+        and (
+            existing.get("ended_at") is not None or not existing.get("pid_alive", True)
+        )
     )
 
     entrypoint = await asyncio.to_thread(detect_entrypoint, pid=payload.pid)
@@ -180,8 +184,12 @@ async def receive_statusline(body: dict) -> dict:
 
     existing = await schema.get_session(db, session_id=session_id)
     is_new = existing is None
-    is_resumed = existing is not None and (
-        existing.get("ended_at") is not None or not existing.get("pid_alive", True)
+    is_resumed = (
+        existing is not None
+        and existing.get("last_event") != "SessionEnd"
+        and (
+            existing.get("ended_at") is not None or not existing.get("pid_alive", True)
+        )
     )
 
     if is_new or is_resumed:

--- a/src/agentpulse/platforms/claude/schema.py
+++ b/src/agentpulse/platforms/claude/schema.py
@@ -192,8 +192,14 @@ async def upsert_session(
                 WHEN excluded.source_system != '' THEN excluded.source_system
                 ELSE source_system
             END,
-            pid_alive = 1,
-            ended_at = NULL
+            pid_alive = CASE
+                WHEN excluded.last_event = 'SessionEnd' THEN pid_alive
+                ELSE 1
+            END,
+            ended_at = CASE
+                WHEN excluded.last_event = 'SessionEnd' THEN ended_at
+                ELSE NULL
+            END
         """,
         (
             session_id,

--- a/src/agentpulse/tray/state.py
+++ b/src/agentpulse/tray/state.py
@@ -41,4 +41,4 @@ class TrayState:
     def tooltip(self) -> str:
         with self._lock:
             status = "Running" if self.connected else "Stopped"
-            return f"AgentPulse — {status} — {self.active_sessions} active"
+            return f"AgentPulse - {status} - {self.active_sessions} active"

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -116,6 +116,36 @@ class TestReceiveHook:
         row = run_async(schema.get_session(db, session_id="s1"))
         assert row["ended_at"] is not None
 
+    def test_statusline_after_session_end_preserves_ended_at(self, client, db) -> None:
+        """A statusline arriving after SessionEnd must not revive the session."""
+        client.post(
+            "/hooks/claude",
+            json={
+                "session_id": "s1",
+                "hook_event_name": "PreToolUse",
+            },
+        )
+        client.post(
+            "/hooks/claude",
+            json={
+                "session_id": "s1",
+                "hook_event_name": "SessionEnd",
+            },
+        )
+        row = run_async(schema.get_session(db, session_id="s1"))
+        assert row["ended_at"] is not None
+
+        client.post(
+            "/statusline/claude",
+            json={
+                "session_id": "s1",
+                "cost": {"total_cost_usd": 0.05},
+            },
+        )
+        row = run_async(schema.get_session(db, session_id="s1"))
+        assert row["ended_at"] is not None
+        assert row["last_event"] == "SessionEnd"
+
     def test_events_appended_to_log(self, client, db) -> None:
         client.post(
             "/hooks/claude",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -213,6 +213,34 @@ class TestSessionCrud:
         assert row["pid_alive"] == 1
         assert row["ended_at"] is None
 
+    async def test_upsert_session_end_does_not_revive(self, db) -> None:
+        """A SessionEnd upsert must not clear ended_at or set pid_alive=1."""
+        await schema.upsert_session(db, session_id="s1", pid=1, cwd="/tmp/proj")
+        await schema.end_session(db, session_id="s1", ended_at=99.0)
+        await schema.update_session_pid_alive(db, session_id="s1", pid_alive=False)
+
+        await schema.upsert_session(
+            db,
+            session_id="s1",
+            last_event="SessionEnd",
+            last_event_at=100.0,
+        )
+        row = await schema.get_session(db, session_id="s1")
+        assert row["ended_at"] == 99.0
+        assert row["pid_alive"] == 0
+
+    async def test_upsert_without_event_revives(self, db) -> None:
+        """An upsert with no last_event (e.g. statusline) can revive a session
+        that ended via PID death. The statusline handler guards against
+        reviving SessionEnd sessions separately."""
+        await schema.upsert_session(db, session_id="s1", pid=1, cwd="/tmp/proj")
+        await schema.end_session(db, session_id="s1", ended_at=99.0)
+
+        await schema.upsert_session(db, session_id="s1", cwd="/tmp/proj")
+        row = await schema.get_session(db, session_id="s1")
+        assert row["ended_at"] is None
+        assert row["pid_alive"] == 1
+
     async def test_source_system(self, db) -> None:
         await schema.upsert_session(
             db,

--- a/tests/tray/test_state.py
+++ b/tests/tray/test_state.py
@@ -79,4 +79,4 @@ def test_status_label_stopped() -> None:
 
 def test_tooltip() -> None:
     s = TrayState(connected=True, active_sessions=1)
-    assert s.tooltip() == "AgentPulse — Running — 1 active"
+    assert s.tooltip() == "AgentPulse - Running - 1 active"


### PR DESCRIPTION
upsert_session unconditionally set ended_at=NULL and pid_alive=1 on
conflict, which let a post-mortem statusline update revive a session
that had just received SessionEnd. Now upsert_session preserves both
fields when last_event is SessionEnd, and the statusline handler skips
revival for sessions whose last_event is SessionEnd.

Also replace em dashes in tray tooltip with ASCII hyphens to fix a
UnicodeEncodeError on X11 (WM_NAME uses Latin-1).

Closes #16
Assisted-by: Claude Code (Claude Opus 4.6)
