### PR TITLE
docs: add data model proposal and relay payload references

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -7,32 +7,50 @@
 
 Default host/port: `127.0.0.1:17385` (configured in `config.json`).
 
-## Bootstrap Pattern
+## Data model
+
+The primary entity is a **process** — an OS-level Claude Code instance
+identified by `(pid, source_system, cwd)`. Sessions are children of a
+process. When a user runs `/clear` inside Claude Code, a new
+`session_id` is issued but the underlying process keeps running; the new
+session joins the same process group.
+
+Cumulative metrics (`cost_usd`, `total_input_tokens`, `total_output_tokens`,
+`lines_added`, `lines_removed`) live on the **process**. Per-session
+fields (`last_event`, `last_tool`, `context_used_pct`, `model_name`, agents)
+reset when `/clear` starts a new session within the same process.
+
+## Bootstrap pattern
 
 1. Connect to WebSocket
-2. Fetch initial state: `GET /api/v1/sessions` (all sessions with current data)
+2. Fetch initial state: `GET /api/v1/sessions` — returns a list of processes with nested sessions
 3. Optionally fetch `GET /api/v1/limits` (usage quotas, if enabled)
-4. Apply WebSocket messages incrementally to the local state
+4. Apply WebSocket messages incrementally to the local state. Every
+   session-scoped WebSocket message carries `pid` and `source_system` so
+   clients can map a message to its process without a REST lookup.
 
-## WebSocket Protocol
+## WebSocket protocol
 
 - **Receive-only** — the server does not process incoming messages from clients
 - **No server-initiated pings** — clients that expect pings will timeout and disconnect. Disable ping expectations or send client-side keep-alive
 - **JSON text frames** — every message is `JSON.parse()`-able
 - **All messages have:** `type` (string), `platform` (string), `timestamp` (float, Unix epoch)
-- **Most messages have:** `session_id` (string, UUID)
+- **Session-scoped messages have:** `session_id`, `pid`, `source_system`. The triplet `(pid, source_system, cwd)` identifies the enclosing process; `cwd` arrives through `session_discovered` and the REST state.
 
-## Message Types
+## Message types
 
 ### session_discovered
 
-Fired when discovery finds a new session file in `~/.claude/sessions/`. This is the first time agentpulse sees the session — it may not have any hook or statusline data yet.
+Fired when a new session is seen for the first time (a hook event creates the
+session row).
 
 ```json
 {
   "type": "session_discovered",
   "platform": "claude",
   "session_id": "uuid",
+  "pid": 12345,
+  "source_system": "host.example",
   "event_name": null,
   "tool_name": null,
   "agent_id": null,
@@ -41,17 +59,23 @@ Fired when discovery finds a new session file in `~/.claude/sessions/`. This is 
 }
 ```
 
-**Client action:** Add the session to local state. Fetch `GET /api/v1/sessions/{id}` for full details if needed.
+**Client action:** Find the process group with matching `(pid, source_system, cwd)`
+and add the session, or create a new process entry. Fetch
+`GET /api/v1/sessions/{id}` for full process detail if needed.
 
 ### session_ended
 
-Fired when a session's PID dies (detected by discovery) or a `SessionEnd` hook event arrives. The session remains in the database with `ended_at` set — it is not deleted.
+Fired when a session's PID dies (detected by discovery) or a `SessionEnd` hook
+event arrives. The session remains in the database with `ended_at` set — it is
+not deleted.
 
 ```json
 {
   "type": "session_ended",
   "platform": "claude",
   "session_id": "uuid",
+  "pid": 12345,
+  "source_system": "host.example",
   "event_name": null,
   "tool_name": null,
   "agent_id": null,
@@ -60,17 +84,23 @@ Fired when a session's PID dies (detected by discovery) or a `SessionEnd` hook e
 }
 ```
 
-**Client action:** Mark the session as ended in local state. Do not remove it — the user may want to see historical sessions.
+**Client action:** Mark the session as ended in local state. Do not remove it
+— the user may want to see historical sessions.
 
 ### session_cleared
 
-Fired when `POST /api/v1/sessions/{id}/clear` is called. Resets the session's last_event/last_tool/last_event_at to null and ends all active agents. Used when Claude Code is interrupted and no hook events fire.
+Fired when `POST /api/v1/sessions/{id}/clear` is called. Resets the
+session's `last_event`/`last_tool`/`last_event_at` to null and ends all
+active agents. Used when Claude Code is interrupted and no hook events
+fire.
 
 ```json
 {
   "type": "session_cleared",
   "platform": "claude",
   "session_id": "uuid",
+  "pid": 12345,
+  "source_system": "host.example",
   "event_name": "clear_state",
   "tool_name": null,
   "agent_id": null,
@@ -83,13 +113,16 @@ Fired when `POST /api/v1/sessions/{id}/clear` is called. Resets the session's la
 
 ### hook_event
 
-Fired on every Claude Code hook event — tool calls, prompts, stops. This is the primary state change signal. The `event_name` tells you what happened.
+Fired on every Claude Code hook event — tool calls, prompts, stops. This is
+the primary state change signal. The `event_name` tells you what happened.
 
 ```json
 {
   "type": "hook_event",
   "platform": "claude",
   "session_id": "uuid",
+  "pid": 12345,
+  "source_system": "host.example",
   "event_name": "PreToolUse",
   "tool_name": "Bash",
   "agent_id": null,
@@ -108,7 +141,10 @@ Common `event_name` values:
 
 When `agent_id` is non-null, the event is from a subagent, not the main session.
 
-**Client action:** Update the session's displayed state based on `event_name`. Use `derive_state` logic if you want to compute working/idle/permission_required: PreToolUse→working, PermissionRequest→permission_required, Stop→idle, etc.
+**Client action:** Update the session's displayed state based on `event_name`.
+Use `derive_state` logic if you want to compute working/idle/permission_required:
+`PreToolUse` → `working`, `PermissionRequest` → `permission_required`,
+`Stop` → `idle`, etc.
 
 ### agent_started
 
@@ -119,6 +155,8 @@ Fired when a subagent starts within a session.
   "type": "agent_started",
   "platform": "claude",
   "session_id": "uuid",
+  "pid": 12345,
+  "source_system": "host.example",
   "event_name": "SubagentStart",
   "tool_name": null,
   "agent_id": "agent-uuid",
@@ -138,6 +176,8 @@ Fired when a subagent completes or is cancelled.
   "type": "agent_stopped",
   "platform": "claude",
   "session_id": "uuid",
+  "pid": 12345,
+  "source_system": "host.example",
   "event_name": "SubagentStop",
   "tool_name": null,
   "agent_id": "agent-uuid",
@@ -150,15 +190,24 @@ Fired when a subagent completes or is cancelled.
 
 ### statusline_update
 
-Fired when statusline data arrives from Claude Code (cost, tokens, context window, model). This is the richest data source for session metrics. Fires frequently — typically after each tool call.
+Fired when statusline data arrives from Claude Code (cost, tokens, context
+window, model). This is the richest data source for session metrics. Fires
+frequently — typically after each tool call. Only broadcast when the
+enclosing session exists; statusline rows for unknown sessions are stored
+but not broadcast until a hook creates the session.
 
 ```json
 {
   "type": "statusline_update",
   "platform": "claude",
   "session_id": "uuid",
+  "pid": 12345,
+  "source_system": "host.example",
   "cost_usd": 5.25,
-  "prior_cost_usd": 1.10,
+  "cost_by_day": {
+    "2026-04-22": 4.15,
+    "2026-04-23": 1.10
+  },
   "context_used_pct": 25,
   "model_name": "Opus 4.6 (1M context)",
   "total_input_tokens": 10000,
@@ -169,13 +218,22 @@ Fired when statusline data arrives from Claude Code (cost, tokens, context windo
 }
 ```
 
-**Client action:** Update the session's cost, context, model, and token displays. This is a full snapshot — replace, don't accumulate.
+**Client action:** Update the enclosing process's cost, tokens, and lines
+from this snapshot (they apply to the whole process group). Update the
+session's `context_used_pct` and `model_name`. This is a full snapshot —
+replace, don't accumulate.
 
-`cost_usd` is the session's lifetime cumulative cost. `prior_cost_usd` is the portion accrued before today's local midnight (server TZ). Today's cost = `cost_usd - prior_cost_usd`. `prior_cost_usd` is `0.0` for sessions that started today or have no statusline rows. The same field is present on every REST session response (`/api/v1/sessions`, `/api/v1/sessions/{id}`).
+- `cost_usd` is the process's lifetime cumulative cost.
+- `cost_by_day` is a dict keyed by `YYYY-MM-DD` (server local time) with
+  per-day cost deltas. Sum across keys to recover `cost_usd` (within
+  rounding). Clients that want "today's cost" read `cost_by_day[today]`
+  directly; "prior-day cost" is the sum of every other day.
 
 ### limits_updated
 
-Fired when fresh usage limits are fetched from the Anthropic OAuth API. Only fires when `fetch_limits` is enabled in config and the TTL has expired. Not session-specific.
+Fired when fresh usage limits are fetched from the Anthropic OAuth API. Only
+fires when `fetch_limits` is enabled in config and the TTL has expired. Not
+session-specific.
 
 ```json
 {
@@ -194,20 +252,81 @@ Fired when fresh usage limits are fetched from the Anthropic OAuth API. Only fir
 }
 ```
 
-**Client action:** Update the global limits display. Use `refresh_after` to know when the next update will arrive.
+**Client action:** Update the global limits display. Use `refresh_after` to
+know when the next update will arrive.
 
-## REST API Reference
+## REST API reference
 
 ### Sessions
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/v1/sessions` | All sessions. `?active=true` for live only |
-| GET | `/api/v1/sessions/{id}` | Session detail with agents |
-| GET | `/api/v1/sessions/{id}/events` | Event history. `?limit=N&offset=N&since=T` |
+| GET | `/api/v1/sessions` | Processes with nested sessions. `?active=true` for processes whose current session is live |
+| GET | `/api/v1/sessions/{id}` | Process containing this session, with all sibling sessions nested |
+| GET | `/api/v1/sessions/{id}/events` | Event history for this session. `?limit=N&offset=N&since=T` |
 | GET | `/api/v1/sessions/{id}/agents` | Session's agents |
 | POST | `/api/v1/sessions/{id}/clear` | Reset session state |
-| GET | `/api/v1/summary` | Aggregate stats + limits |
+| GET | `/api/v1/summary` | Aggregate stats (uses `active_processes`) + limits |
+
+### Response shape
+
+`GET /api/v1/sessions` returns a list of process objects:
+
+```json
+[
+  {
+    "pid": 12345,
+    "source_system": "host.example",
+    "platform": "claude",
+    "cwd": "/path/to/project",
+    "entrypoint": "vscode",
+    "pid_alive": true,
+    "branch": "",
+    "started_at": 1776703873232,
+    "current_session_id": "a415cfed-...",
+    "derived_state": "working",
+    "cost_usd": 83.58,
+    "cost_by_day": {
+      "2026-04-22": 82.54,
+      "2026-04-23": 1.04
+    },
+    "total_input_tokens": 292478,
+    "total_output_tokens": 512427,
+    "lines_added": 6269,
+    "lines_removed": 944,
+    "sessions": [
+      {
+        "session_id": "9a4cc0a4-...",
+        "platform": "claude",
+        "started_at": 1776703873232,
+        "ended_at": 1776946322.14,
+        "last_event": "SessionEnd",
+        "last_tool": "Bash",
+        "last_event_at": 1776946322.14,
+        "context_used_pct": 43,
+        "model_name": "Opus 4.6 (1M context)",
+        "agent_count": 0,
+        "derived_state": null,
+        "agents": []
+      },
+      {
+        "session_id": "a415cfed-...",
+        "platform": "claude",
+        "started_at": 1776946322574,
+        "ended_at": null,
+        "last_event": "PostToolUse",
+        "last_tool": "Read",
+        "last_event_at": 1776947339.99,
+        "context_used_pct": 6,
+        "model_name": "Opus 4.6 (1M context)",
+        "agent_count": 0,
+        "derived_state": "working",
+        "agents": []
+      }
+    ]
+  }
+]
+```
 
 ### Limits
 
@@ -216,23 +335,27 @@ Fired when fresh usage limits are fetched from the Anthropic OAuth API. Only fir
 | GET | `/api/v1/limits` | Current usage limits |
 | GET | `/api/v1/limits/history` | Historical snapshots. `?limit=N&offset=N&since=T` |
 
-### Platform-Specific (Raw)
+### Platform-specific (raw)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/v1/claude/sessions` | Raw claude_sessions rows |
+| GET | `/api/v1/claude/sessions` | Raw `claude_sessions` rows (no process grouping) |
 | GET | `/api/v1/claude/events` | Raw events. `?session_id=X&event_name=X&since=T&until=T` |
 
-### Ingestion (Internal)
+### Ingestion (internal)
 
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/hooks/claude` | Hook relay events |
 | POST | `/statusline/claude` | Statusline data |
 
-## Derived State
+## Derived state
 
-The REST API includes a `derived_state` field on sessions. This is computed from `last_event` and `last_tool` at query time. WebSocket clients that want to derive state from `hook_event` messages can use this mapping:
+The REST API includes a `derived_state` field on each session and also on
+the process (copied from the current session's effective state). This is
+computed from `last_event` and `last_tool` at query time. WebSocket
+clients that want to derive state from `hook_event` messages can use this
+mapping:
 
 | event_name | tool_name | derived_state |
 |------------|-----------|---------------|
@@ -244,26 +367,6 @@ The REST API includes a `derived_state` field on sessions. This is computed from
 | `PostToolUse` | — | `working` |
 | `Stop` | — | `idle` |
 
-When a session has active agents, the effective state is the highest-priority state across the main session and all agents. Priority (highest first): `permission_required` > `awaiting_input` > `working` > `ready` > `idle`.
-
-## Cost and Token Aggregation
-
-Claude Code tracks cumulative metrics **per process**, not per `session_id`. When a user runs `/clear` inside Claude Code, a new `session_id` is issued but the process keeps its cost/token counters running. AgentPulse stores each `session_id`'s latest snapshot faithfully — so **summing across sessions double-counts**.
-
-**Cumulative per process** (inherited across `/clear`): `cost_usd`, `total_input_tokens`, `total_output_tokens`, `lines_added`, `lines_removed`.
-
-**Per session_id** (reset on `/clear`): `context_used_pct`, `last_event`, `last_tool`, agents.
-
-### Detecting a chain
-
-Sessions sharing `(source_system, pid)` are the same Claude Code process — a chain of `/clear` rotations. The first statusline of each chained session equals the last statusline of the previous one.
-
-### Aggregation recipe
-
-To report accurate cost/token totals:
-
-1. Group sessions by `(source_system, pid)`.
-2. Within each group, pick the session with the highest `last_event_at` (fall back to `started_at` if null).
-3. Use only that one session's `cost_usd` / tokens / lines. Discard the older snapshots in the group.
-
-For per-project (cwd) or per-host totals, sum the per-process latest values across groups. For UI display, collapse chained sessions into a single row representing the live process, and surface the older session_ids as historical clears if needed.
+When a session has active agents, the effective state is the highest-priority
+state across the main session and all agents. Priority (highest first):
+`permission_required` > `awaiting_input` > `working` > `ready` > `idle`.

--- a/docs/database-proposed.md
+++ b/docs/database-proposed.md
@@ -1,0 +1,403 @@
+# Data Model — Proposed
+
+Future-state data architecture. What entities we want to capture, what
+each entity carries, and how they relate. No current-state comparison, no
+migration plan, no query implementation — those are separate concerns.
+
+## Naming convention
+
+All append-only log tables are prefixed **`claude_log_`**. Any future
+derived projection, materialized cache, or operational-state table uses
+a different prefix (`claude_view_`, `claude_cache_`, `claude_state_`).
+The `log_` marker tells a reader at a glance whether a table is
+append-only (safe to scan, safe to snapshot, safe to rebuild from
+upstream) or something more delicate.
+
+## Design principles
+
+1. **Every external signal is captured raw, exactly once, in its own
+   log.** No upserts, no deletes. One channel, one table.
+2. **Every row is self-describing.** Context needed to interpret a row
+   is denormalized onto the row — `pid`, `source_system`, `cwd`,
+   `entrypoint` travel with each event rather than living on a
+   separately-updated "session" row.
+3. **Higher-level entities (session, agent, process) are derived.**
+   They are concepts the data model *describes*, not rows that are
+   stored. Their current state is a projection over the logs.
+4. **Process lifetimes are first-class, grounded in PID history.** A
+   process is defined by a span of events sharing `pid` within a single
+   `session_id` — an *epoch*. Resumes and PID reuse both resolve
+   correctly because the PID stream is the source of truth.
+5. **Time is normalized to one unit throughout.** Every stored
+   timestamp is a `REAL` column holding **Unix epoch seconds** with
+   fractional precision. Any payload value that arrives in milliseconds
+   (e.g. statusline's `total_duration_ms`) is divided by 1000 at
+   ingestion. Comparisons, arithmetic, and rendering become trivial;
+   consumers never have to ask "what unit is this?"
+
+## Design constraints
+
+Deliberate limitations of the current model. These are the assumptions
+a reader should check before assuming behavior outside their scope.
+
+### Single Anthropic account
+
+The data model assumes **one Anthropic account** per agentpulse
+deployment. API usage limits, OAuth credentials, and any future
+account-scoped fields are treated as implicit — not captured as a
+column on any table.
+
+Why this is a model-wide constraint, not a table-local one:
+- Limits are account-scoped, but so are the credentials that drove
+  the hook and statusline events. If a user switched between accounts
+  mid-run, hooks and statuslines from different accounts would
+  commingle in one log and there would be no way to demux them.
+- The signals we capture today (hooks, statuslines, pid observations,
+  limits) all have no native account identifier. Obtaining one would
+  require decoding the opaque OAuth token or calling an identity
+  endpoint — neither of which exists in the ingestion path today.
+- Adding an `account_id` column to one table while leaving the others
+  un-scoped would create a phantom dimension that can't be joined
+  meaningfully.
+
+If multi-account becomes a real need, the work is coordinated across
+*every* log table — add `account_id` (or equivalent) everywhere,
+source it at ingestion, and make consumers account-aware. Do not add
+it piecemeal.
+
+## Audit columns
+
+Every log table carries:
+
+- `id INTEGER PK` — autoincrement surrogate. Row uniqueness and stable
+  ordering. Never reused, never mutated.
+- A pair describing when the row was written and by whom:
+  - **Wire-sourced logs** (`claude_log_hooks`, `claude_log_statuslines`,
+    `claude_log_api_limits`): `received_at` (REAL seconds) +
+    `received_by` (writer identity string). "We received this from the
+    outside world at this moment."
+  - **Observation-sourced logs** (`claude_log_pid_deaths`):
+    `observed_at` + `observed_by`. "We looked out and observed this at
+    this moment."
+
+Append-only logs deliberately have **no `last_updated_*` counterparts**
+— rows never mutate, so the absence is the signal that an UPDATE
+against these tables is wrong.
+
+## Entity overview
+
+```mermaid
+erDiagram
+    claude_log_hooks            ||--o{ claude_log_statuslines      : "session_id"
+    claude_log_hooks            ||--o{ claude_log_pid_deaths       : "pid, source_system, cwd"
+    claude_log_api_limits {
+        INTEGER id PK
+    }
+```
+
+All relationships are logical — no referential integrity enforcement.
+Data arrives out of order and sometimes for sessions that don't yet
+exist, so the integrity is in the query, not the write.
+
+`claude_log_api_limits` is shown standalone — it's not session-scoped.
+
+## Log tables
+
+### `claude_log_hooks`
+
+One row per hook event emitted by Claude Code. Claude Code hooks cover
+every observable runtime signal: tool calls, prompts, stops, session
+start/end, subagent lifecycle, permission requests, notifications.
+
+```mermaid
+erDiagram
+    claude_log_hooks {
+        INTEGER id                PK "autoincrement surrogate"
+        INTEGER pid               UK "Claude Code CLI PID at event time"
+        TEXT    session_id        UK
+        TEXT    source_system     UK "hostname of the machine running Claude"
+        TEXT    cwd               UK "working directory at event time"
+        TEXT    agent_id          UK "nullable; main-session thread = null"
+        TEXT    event_name
+        TEXT    tool_name         "nullable; PreToolUse/PostToolUse/PermissionRequest"
+        TEXT    agent_type        "nullable; set on SubagentStart"
+        TEXT    permission_mode   "e.g. acceptEdits, plan"
+        TEXT    entrypoint        "cli, vscode, cursor, jetbrains, ..."
+        TEXT    claude_version    "e.g. 2.1.117"
+        REAL    received_at       "service wall-clock when handler began"
+        TEXT    received_by       "writer identity, e.g. hook-endpoint"
+        TEXT    raw_payload       "full hook JSON"
+    }
+```
+
+### Natural identity
+
+The `id` column is the row PK (surrogate, autoincrement) — always
+unique, never reused.
+
+The composite `(pid, session_id, source_system, cwd, agent_id)` is a
+**unique key on the actor concept**, not on individual rows. It
+identifies a specific subagent (or the main-session thread when
+`agent_id` is null) within a specific process lifetime, on a specific
+machine, rooted in a specific working directory. Many rows share this
+composite (one per event); SQL-level row uniqueness comes from `id`.
+
+Marked as `UK` in the diagram because that composite is the natural
+access key for queries like "all events from this actor."
+
+**`cwd` is part of the identity** because downstream consumers present
+data scoped by cwd — a project dashboard, a per-repo cost rollup, a
+worktree-specific view. If `cwd` were omitted, a session resumed into a
+different working directory (Claude permits this) would collide with
+its original identity and corrupt the downstream view. Consequence of
+including `cwd`: a resume across working directories creates two
+distinct actor identities sharing the same `session_id`. That matches
+what consumers already expect — "show me what happened in this
+directory" is the natural presentation axis.
+
+Notes:
+- **No enum constraints.** `event_name`, `tool_name`, `agent_type`,
+  `permission_mode`, and `entrypoint` are all free-text. Annotations in
+  the diagram (e.g. "cli, vscode, cursor, jetbrains, ...") are
+  illustrative examples, not schema constraints. Claude Code regularly
+  introduces new values; writes must never fail because the field
+  landed on an unfamiliar string.
+- `pid` travels with every event so process-lifetime detection works
+  even when the current pid differs from the original session's pid.
+- `entrypoint` is captured per event (not per session) so a session
+  resumed from a different launcher records its new entrypoint
+  accurately.
+- `agent_type` is populated on the introducing `SubagentStart` event.
+  Later events for the same `agent_id` leave it null — the type is a
+  property of the agent, not of each event.
+- `received_at` is the service's wall clock at handler entry, not a
+  DB-computed insert time. A few microseconds before the INSERT hits
+  disk in practice. The name describes what happened (we received the
+  POST at this time).
+- `received_by` identifies the writer for audit (e.g. `hook-endpoint`).
+  Append-only logs don't have `last_updated_*` counterparts — rows
+  never mutate, so the absence is the signal that an UPDATE against
+  this table is wrong.
+- `raw_payload` is the escape valve: any future hook field lands here
+  before the schema catches up.
+
+### `claude_log_statuslines`
+
+One row per statusline POST — emitted by Claude Code roughly once per
+tool call, carrying cost/token/context snapshots. See
+[`statusline-payload.md`](statusline-payload.md) for the full wire
+shape.
+
+```mermaid
+erDiagram
+    claude_log_statuslines {
+        INTEGER id                    PK "autoincrement surrogate"
+        INTEGER pid                   UK
+        TEXT    session_id            UK
+        TEXT    source_system         UK
+        TEXT    cwd                   UK
+        TEXT    project_dir           "workspace.project_dir; may differ from cwd"
+        TEXT    model_id              "e.g. claude-opus-4-7[1m]"
+        TEXT    model_name            "e.g. Opus 4.7 (1M context)"
+        TEXT    claude_version
+        REAL    cost_usd              "cumulative over Claude PROCESS lifetime"
+        INTEGER total_input_tokens
+        INTEGER total_output_tokens
+        REAL    context_used_pct
+        INTEGER context_window_size
+        INTEGER cache_read_tokens
+        INTEGER cache_creation_tokens
+        REAL    duration_seconds      "from payload's total_duration_ms, normalized"
+        REAL    api_duration_seconds  "from payload's total_api_duration_ms, normalized"
+        INTEGER lines_added
+        INTEGER lines_removed
+        BOOLEAN exceeds_200k_tokens
+        REAL    received_at           "service wall-clock when handler began"
+        TEXT    received_by           "writer identity, e.g. statusline-endpoint"
+        TEXT    raw_payload
+    }
+```
+
+Natural identity: `(pid, session_id, source_system, cwd)` — marked
+`UK` in the diagram. Statuslines have no subagent dimension (only the
+main CLI renders statuslines), so no `agent_id` component. Many rows
+share this composite over time; row uniqueness is the `id` surrogate.
+
+Notes:
+- `pid` and `source_system` travel on each row so the process-epoch
+  concept applies to statusline-only ingestion (statusline can arrive
+  before the first hook for a session_id).
+- `cost_usd` is **cumulative over a Claude process lifetime**, not per
+  session. Persists across `/clear` within one process. Resets on
+  `claude --resume` into a new process. See the *process epoch*
+  concept below for how this is interpreted.
+- `project_dir` is distinct from `cwd`: the workspace's logical root
+  versus the current directory when Claude was launched. Both matter.
+- `rate_limits` (bundled inside statusline payloads) is intentionally
+  left in `raw_payload` only — the OAuth-API-sourced
+  `claude_log_api_limits` stream is a cleaner source for that data.
+
+### `claude_log_pid_deaths`
+
+A PID's lifecycle is not a stream of events; it's an entity with a
+birth and a death. First-observed and last-observed timestamps are
+derivable from the hooks and statusline logs themselves
+(`MIN(received_at)` / `MAX(received_at)` for rows matching the pid).
+The one signal that *isn't* derivable from activity logs is the
+**death** — absence of hooks doesn't prove a PID is gone; it might
+just be idle. The watcher provides that signal.
+
+So: rather than model the full PID lifecycle here, capture only the
+discrete events that can't be derived elsewhere — observations that
+a watcher made about a PID's demise or replacement.
+
+```mermaid
+erDiagram
+    claude_log_pid_deaths {
+        INTEGER id             PK "autoincrement surrogate"
+        INTEGER pid            UK
+        TEXT    source_system  UK
+        TEXT    cwd            UK
+        REAL    observed_at       "service wall-clock when watcher confirmed death"
+        TEXT    observed_by       "writer identity, e.g. pid-watcher"
+    }
+```
+
+Natural identity: `(pid, source_system, cwd)` — marked `UK` in the
+diagram. Identifies a process instance (machine + cwd + PID). Note
+that multiple death rows can share this composite when a PID is reused
+over time; the composite identifies the *process-instance concept*,
+not a specific death event. Each row is a discrete death observation,
+ordered by `observed_at`; disambiguating which death belongs to which
+instance uses the `observed_at` timeline plus activity gaps in the
+hooks/statuslines logs.
+
+Notes:
+- The table's scope *is* deaths — every row asserts "this process
+  instance is gone, as observed by this writer at this moment." No
+  kind/type/observation column is needed; the signal is the row's
+  existence.
+- What counts as death is up to the watcher. The current PID watcher
+  would write a row for: the OS reports no process at that PID, or
+  the OS reports a process at that PID whose image doesn't match the
+  Claude instance we were tracking (PID reuse, from our perspective:
+  our process is dead). Future watchers can add detection paths
+  without schema changes — the output is the same row shape.
+- If a future need arises to capture *evidence* or *detection reason*
+  for diagnostics (not for decision-making), it can land as an
+  additional column later. Leaving it out keeps the table lean until a
+  consumer needs it.
+- `source_system` and `cwd` travel on the row so each death is
+  self-describing without joining back to hooks.
+- `observed_at` and `observed_by` follow the same naming convention as
+  `received_at` / `received_by` elsewhere — different prefix because
+  the watcher is *observing* a process out in the world, not
+  *receiving* a payload over the wire.
+
+### `claude_log_api_limits`
+
+One row per successful pull from the Anthropic OAuth usage-limits API.
+Not session-scoped and not machine-scoped. Limits belong to the
+Anthropic account — the same account used from multiple machines
+shares one pool. Account scope is deliberately implicit here; see
+**Single Anthropic account** under *Design constraints*.
+
+```mermaid
+erDiagram
+    claude_log_api_limits {
+        INTEGER id                         PK "autoincrement surrogate"
+        REAL    received_at                   "service wall-clock when fetch completed"
+        TEXT    received_by                   "writer identity, e.g. limits-fetcher"
+        REAL    five_hour_utilization         "percentage 0-100"
+        REAL    five_hour_resets_at           "epoch seconds; nullable"
+        REAL    seven_day_utilization         "percentage 0-100"
+        REAL    seven_day_resets_at           "epoch seconds; nullable"
+        TEXT    raw_response                  "full API response JSON"
+    }
+```
+
+No natural-identity composite. Each row is one fetch event;
+uniqueness is the `id` surrogate. Account scope is handled at the
+model level (see **Single Anthropic account** under *Design
+constraints*), not on this table.
+
+Notes:
+- Extracted columns cover the two buckets consumers care about today:
+  `five_hour` and `seven_day`. Other buckets in the API response
+  (`seven_day_opus`, `seven_day_sonnet`, `seven_day_oauth_apps`,
+  `extra_usage`, and a handful of variants) live in `raw_response` and
+  can be promoted to columns if a consumer needs them.
+- `resets_at` fields arrive from the API as ISO 8601 strings (e.g.
+  `"2026-04-24T02:30:00.202303+00:00"`) and are normalized to epoch
+  seconds at ingestion per the time-normalization principle.
+- `five_hour_resets_at` and `seven_day_resets_at` are nullable — the
+  API returns `null` when the bucket hasn't been used recently enough
+  to have an active reset timer.
+- `received_at`/`received_by` follow the same convention as the other
+  log tables; the fetcher is the writer for this stream. If attribution
+  of *which machine did the fetch* becomes useful for ops/debugging,
+  it can land as an optional `fetched_by_system` column — separate
+  concern from account scoping.
+
+## Derived concepts
+
+None of the following are stored. They are the domain concepts the logs
+describe. A query helper or SQL view computes them on demand.
+
+### Session
+
+Identified by `session_id`. Its current state is the latest row in
+`claude_log_hooks` for that session_id (with statusline enrichment
+from the latest `claude_log_statuslines` row).
+
+### Agent
+
+Identified by `agent_id`. Current state is the latest
+`claude_log_hooks` row for that agent_id. Lifetime is bounded by
+`SubagentStart`/`SubagentStop` events for the same `agent_id`.
+
+### Process epoch
+
+A **process epoch** is a contiguous span of rows sharing the same
+`(session_id, pid)` with no interruption. A pid change within a
+session_id starts a new epoch — this is the hallmark of
+`claude --resume` into a new process.
+
+Each epoch has:
+- `session_id`
+- `pid`
+- `source_system`, `cwd`, `entrypoint` (from the rows in the epoch)
+- `started_at` = min(received_at) within the span
+- `ended_at` = max(received_at) within the span, or null if ongoing.
+  A matching `claude_log_pid_deaths.observed_at` (if present) firms
+  this up into a definitive end rather than a "most recent activity"
+  approximation.
+
+### Process
+
+A **process** is the union of epochs that belong to the same Claude
+Code process lifetime. A single Claude process can host multiple
+sessions (every `/clear` mints a new session_id within the same
+process), so one process covers N session_ids.
+
+Process identity:
+- Epochs sharing `(pid, source_system, cwd)` whose time windows do
+  not overlap are **distinct processes** (PID reuse).
+- Epochs sharing `(pid, source_system, cwd)` whose time windows
+  overlap or are contiguous are the **same process**.
+
+Cumulative cost for a process = the max `cost_usd` observed in
+`claude_log_statuslines` within the process's time window (monotonic
+by construction).
+
+## Future entities
+
+Captured here so the namespace stays coherent when these land:
+
+- **`claude_log_external_costs`** — future ingestion from external cost
+  feeds (e.g. ccusage-style daily rollups). Shape TBD; would carry
+  `source_system`, `recorded_at`, and cost/token breakdowns. Not added
+  to the data model until a writer exists.
+- **`claude_view_*`** — materialized projections (session list,
+  process list) for fast reads. Added only if log-query latency
+  becomes unacceptable in practice.

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,244 @@
+# Database Schema
+
+AgentPulse uses a single SQLite database (default `~/.claude/agentpulse/agentpulse.db`,
+WAL mode) with tables scoped per platform. All current tables are prefixed
+`claude_` — future platforms get their own prefix.
+
+- **Location**: `config.db_path` in `~/.claude/agentpulse/config.json`.
+- **Journaling**: WAL. Snapshots taken while the service runs **must** use
+  `sqlite3 <db> ".backup <dest>"` or copy all three of `.db`, `.db-wal`,
+  `.db-shm`. A bare `cp` of only the `.db` file misses uncommitted WAL pages.
+- **Migrations**: none today. Schema changes that alter an existing column
+  require dropping the DB or writing a one-off migration.
+- **Definitions**: [`src/agentpulse/platforms/claude/schema.py`](../src/agentpulse/platforms/claude/schema.py).
+
+## Entity-relationship overview
+
+```mermaid
+erDiagram
+    claude_sessions ||--o{ claude_agents : "session_id (FK)"
+    claude_sessions ||--o{ claude_events : "session_id (logical)"
+    claude_sessions ||--o{ claude_statusline : "session_id (logical)"
+    claude_sessions ||--o{ claude_costs : "session_id (logical)"
+    claude_agents  ||--o{ claude_events : "agent_id (logical, nullable)"
+    claude_limits  ||--|| claude_limits : "standalone (no session FK)"
+```
+
+Notes on relationships:
+
+- `claude_agents.session_id` is the only **enforced** foreign key.
+- `claude_events.session_id`, `claude_statusline.session_id`, and
+  `claude_costs.session_id` are **logical** references — no FK constraint, so
+  rows can arrive for unknown sessions (e.g. a statusline row for a
+  `session_id` the hook path hasn't created yet).
+- `claude_events.agent_id` is nullable; when non-null it references an
+  `agent_id` in `claude_agents`, also logical.
+- `claude_limits` is not session-scoped — one global stream of API limit
+  snapshots.
+
+## Tables
+
+### `claude_sessions`
+
+Current-state snapshot for each Claude Code session. **Single row per
+`session_id`**, updated via upsert on each hook event. This is a "latest
+state" view, not a log — fields like `pid`, `last_event`, `pid_alive` are
+overwritten.
+
+```mermaid
+erDiagram
+    claude_sessions {
+        TEXT    session_id PK
+        INTEGER pid
+        TEXT    cwd
+        TEXT    entrypoint
+        INTEGER started_at
+        TEXT    last_event
+        TEXT    last_tool
+        REAL    last_event_at
+        REAL    discovered_at
+        REAL    ended_at
+        INTEGER pid_alive
+        TEXT    branch
+        TEXT    source_system
+        REAL    cost_usd "dead column; see note"
+        REAL    context_used_pct
+        TEXT    model_name
+        INTEGER total_input_tokens "dead column"
+        INTEGER total_output_tokens "dead column"
+        INTEGER lines_added "dead column"
+        INTEGER lines_removed "dead column"
+    }
+```
+
+- **`pid`**: reflects the *latest* hook's parent PID. A session resumed via
+  `claude --resume <id>` in a new process overwrites the original PID, so
+  this field alone can't distinguish process lifetimes.
+- **`started_at`**: Unix epoch **milliseconds** (one of two fields that use
+  ms — everything else is seconds).
+- **`discovered_at`**, **`last_event_at`**, **`ended_at`**: Unix epoch
+  seconds.
+- **`pid_alive`**: 0/1. Set to 0 by the discovery loop when
+  `psutil.pid_exists(pid)` returns false.
+- **`cost_usd`, `total_input_tokens`, `total_output_tokens`, `lines_added`,
+  `lines_removed`**: retained for existing DBs but **not written** by
+  current code. Cumulative metrics live in `claude_statusline` and are
+  computed at query time for the enclosing process.
+
+### `claude_agents`
+
+Subagents spawned inside a session. Single row per `agent_id`, upserted on
+each subagent hook event.
+
+```mermaid
+erDiagram
+    claude_agents {
+        TEXT agent_id   PK
+        TEXT session_id FK
+        TEXT agent_type
+        TEXT last_event
+        TEXT last_tool
+        REAL last_event_at
+        REAL started_at
+        REAL ended_at
+    }
+    claude_sessions ||--o{ claude_agents : "session_id"
+```
+
+- `session_id` is a real FK to `claude_sessions`.
+- `agent_type` is the agent template name (e.g. `Explore`, `code-reviewer`).
+- `ended_at` is set when a `SubagentStop` hook fires or when the enclosing
+  session is cleared.
+
+### `claude_events`
+
+**Append-only** log of every hook event the service receives. The full
+payload is preserved in `raw_payload` as JSON.
+
+```mermaid
+erDiagram
+    claude_events {
+        INTEGER id         PK "autoincrement"
+        TEXT    session_id FK "logical"
+        TEXT    agent_id   FK "logical, nullable"
+        TEXT    event_name
+        TEXT    tool_name
+        TEXT    cwd
+        REAL    received_at
+        TEXT    raw_payload "full hook JSON"
+    }
+    claude_sessions ||--o{ claude_events : "session_id"
+    claude_agents  ||--o{ claude_events : "agent_id (nullable)"
+```
+
+- Indexes: `idx_claude_events_session(session_id)`,
+  `idx_claude_events_received(received_at)`.
+- `raw_payload` contains every field the hook relay sent, including `pid`
+  and `source_system`. These are **not** extracted into indexed columns
+  today — callers that need them parse `raw_payload` JSON.
+- `received_at` is the service's wall clock at ingestion, not Claude's
+  timestamp from the payload.
+
+### `claude_statusline`
+
+**Append-only** log of statusline snapshots. Fires roughly once per tool
+call. Source of truth for cumulative per-process metrics (cost, tokens,
+lines).
+
+```mermaid
+erDiagram
+    claude_statusline {
+        INTEGER id                    PK "autoincrement"
+        TEXT    session_id            FK "logical"
+        REAL    received_at
+        REAL    cost_usd
+        INTEGER total_input_tokens
+        INTEGER total_output_tokens
+        REAL    context_used_pct
+        INTEGER context_window_size
+        INTEGER cache_read_tokens
+        INTEGER cache_creation_tokens
+        INTEGER duration_ms
+        INTEGER api_duration_ms
+        INTEGER lines_added
+        INTEGER lines_removed
+        TEXT    model_name
+        TEXT    raw_payload "full statusline JSON"
+    }
+    claude_sessions ||--o{ claude_statusline : "session_id"
+```
+
+- Indexes: `idx_claude_statusline_session(session_id)`,
+  `idx_claude_statusline_received(received_at)`.
+- Statusline rows for unknown `session_id`s are **stored** (for retroactive
+  stitching once the hook creates the session) but the endpoint returns
+  `{"status": "deferred"}`.
+- `cost_usd` is reported by Claude Code and is **not monotonic across all
+  rows for a session_id**: a `claude --resume` starts a new process with a
+  fresh $0 counter, producing a decrease. Per-process-lifetime, the counter
+  is monotonic.
+
+### `claude_costs`
+
+Stub table for a future external cost-ingestion path (e.g. `ccusage`-style
+feeds). The current `POST /costs/claude` endpoint returns 501. The table
+exists so the shape is stable.
+
+```mermaid
+erDiagram
+    claude_costs {
+        TEXT    session_id        FK "logical"
+        REAL    recorded_at
+        REAL    total_cost_usd
+        INTEGER input_tokens
+        INTEGER output_tokens
+        INTEGER cache_read_tokens
+        INTEGER cache_write_tokens
+    }
+    claude_sessions ||--o{ claude_costs : "session_id"
+```
+
+No indexes, no enforcement, no writers in production today.
+
+### `claude_limits`
+
+Snapshots of the Anthropic OAuth API's usage-limits response. Populated only
+when `fetch_limits: true` in config. Not tied to any session.
+
+```mermaid
+erDiagram
+    claude_limits {
+        INTEGER id           PK "autoincrement"
+        REAL    fetched_at
+        TEXT    raw_response "full API response JSON"
+    }
+```
+
+- Index: `idx_claude_limits_fetched(fetched_at)`.
+- The most recent row services both the REST endpoint (`/api/v1/limits`)
+  and the WebSocket `limits_updated` broadcast.
+
+## Writing conventions
+
+| Surface | Writes                                                                |
+|---|---|
+| `POST /hooks/claude` | upsert `claude_sessions`; upsert/end `claude_agents`; append `claude_events` |
+| `POST /statusline/claude` | append `claude_statusline`; update `claude_sessions.context_used_pct` and `model_name` (if session exists) |
+| discovery loop | update `claude_sessions.pid_alive`, `claude_sessions.ended_at` |
+| limits fetch loop | append `claude_limits` |
+| `POST /api/v1/sessions/{id}/clear` | clear event fields on `claude_sessions`; end active agents in `claude_agents`; append synthetic `clear_state` row in `claude_events` |
+
+## Known limitations
+
+- **Session row overwrites lose process-lifetime history.** The stored
+  `pid` on a `claude_sessions` row is the most recent one seen. If a session
+  is resumed from a new process, the original PID is lost. The underlying
+  hook payloads preserve this in `claude_events.raw_payload`, but it isn't
+  indexed for query.
+- **Grouping by `(pid, source_system, cwd)` can collide.** Windows PID
+  reuse and same-session resume into a different PID both break the
+  one-group-one-process invariant. A reset-aware algorithm reading
+  `claude_events` pid history per session is the planned fix.
+- **No migrations.** Adding columns to existing tables requires dropping
+  the DB or writing an ad-hoc migration. `CREATE TABLE IF NOT EXISTS` in
+  `schema.py` only helps fresh databases.

--- a/docs/hooks-payload.md
+++ b/docs/hooks-payload.md
@@ -1,0 +1,153 @@
+# Hook Relay Payload
+
+Reference: what the hook relay (`scripts/hook_relay.py`) emits when
+POSTing to `/hooks/claude`. Purely the wire shape — not what any
+consumer does with it.
+
+The relay script is in this repo at [`scripts/hook_relay.py`](../scripts/hook_relay.py).
+Claude Code invokes it as a hook command; the relay reads Claude's hook
+JSON on stdin, enriches it, and POSTs.
+
+## Upstream reference
+
+Anthropic's hook documentation is the authoritative source for
+Claude-Code-native fields and the catalog of event names:
+**https://code.claude.com/docs/en/hooks**. Anthropic does not publish a
+formal JSON Schema — the docs are prose with examples.
+
+The event list below reflects what we've observed in the wild. Anthropic
+documents **additional events** we haven't yet profiled (`InstructionsLoaded`,
+`UserPromptExpansion`, `PermissionDenied`, `PostToolBatch`,
+`TaskCreated`/`TaskCompleted`, `TeammateIdle`, `CwdChanged`, `FileChanged`,
+`WorktreeCreate`/`WorktreeRemove`, `PreCompact`/`PostCompact`,
+`Elicitation`/`ElicitationResult`, `ConfigChange`, `SessionStart`
+variants). Treat the table as a working subset; the authoritative catalog
+is Anthropic's.
+
+## Example payload (PreToolUse for Bash)
+
+```json
+{
+  "session_id": "uuid",
+  "pid": 12345,
+  "source_system": "host.example",
+  "transcript_path": "C:\\Users\\...\\<session>.jsonl",
+  "cwd": "/path/to/project",
+  "permission_mode": "acceptEdits",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "git status",
+    "description": "Check working tree state"
+  }
+}
+```
+
+Example payload (PostToolUse adds `tool_response`):
+
+```json
+{
+  "session_id": "uuid",
+  "pid": 12345,
+  "source_system": "host.example",
+  "transcript_path": "...",
+  "cwd": "/path/to/project",
+  "permission_mode": "acceptEdits",
+  "hook_event_name": "PostToolUse",
+  "tool_name": "Bash",
+  "tool_input": {"command": "git status", "description": "..."},
+  "tool_response": {
+    "stdout": "...",
+    "stderr": "",
+    "interrupted": false,
+    "isImage": false,
+    "noOutputExpected": false
+  },
+  "tool_use_id": "toolu_01TJAaH..."
+}
+```
+
+Example payload (Stop adds `stop_hook_active`, `last_assistant_message`):
+
+```json
+{
+  "session_id": "uuid",
+  "pid": 12345,
+  "source_system": "host.example",
+  "transcript_path": "...",
+  "cwd": "/path/to/project",
+  "permission_mode": "acceptEdits",
+  "hook_event_name": "Stop",
+  "stop_hook_active": false,
+  "last_assistant_message": "Committed as `664e805`."
+}
+```
+
+## Field origin
+
+| Source | Fields |
+|---|---|
+| Claude Code (native) | `session_id`, `transcript_path`, `cwd`, `permission_mode`, `hook_event_name`, plus event-specific fields (see below) |
+| Relay-injected | `pid`, `source_system` |
+
+### Relay-injected fields
+
+| Field | Type | Computation |
+|---|---|---|
+| `source_system` | string | `platform.node()` — hostname of the machine running Claude Code |
+| `pid` | int | Claude Code's PID. Relay walks `psutil.Process(os.getpid()).parents()` and returns the first ancestor whose process name contains `"claude"`. Falls back to `os.getppid()` if psutil is unavailable or no ancestor matches. |
+
+## Event-specific fields
+
+All hook events carry the base fields (`session_id`, `transcript_path`,
+`cwd`, `permission_mode`, `hook_event_name`, plus the relay-injected
+`pid` and `source_system`). Individual events add:
+
+| `hook_event_name` | Additional fields |
+|---|---|
+| `SessionStart` | `hookSpecificOutput` (hook chain output, sometimes empty) |
+| `SessionEnd` | — (no extra fields beyond the base) |
+| `UserPromptSubmit` | `prompt` (the user's message text) |
+| `PreToolUse` | `tool_name`, `tool_input`, `tool_use_id` |
+| `PostToolUse` | `tool_name`, `tool_input`, `tool_response`, `tool_use_id` |
+| `PostToolUseFailure` | same as `PostToolUse` plus failure detail inside `tool_response` |
+| `PermissionRequest` | `tool_name`, `tool_input`, `tool_use_id` |
+| `Notification` | `message` |
+| `Stop` | `stop_hook_active`, `last_assistant_message` |
+| `StopFailure` | same as `Stop` plus failure detail |
+| `SubagentStart` | `agent_id`, `agent_type`, `tool_input` (the delegated task) |
+| `SubagentStop` | `agent_id`, `agent_type` |
+
+Within subagent-scoped tool events (`PreToolUse`/`PostToolUse` fired by
+a subagent), `agent_id` and `agent_type` also appear alongside the
+tool fields.
+
+## Semantic notes
+
+- `pid` is the Claude Code CLI's process ID **at the moment the hook
+  fired**. When a session is resumed (`claude --resume <session_id>`)
+  from a new shell, the PID in the payload changes even though
+  `session_id` is unchanged. Each POST carries the current pid.
+- `cwd` is Claude's current working directory. Normally matches the
+  shell where `claude` was launched; resume from a different shell can
+  change it.
+- `transcript_path` points to Claude's per-session JSONL transcript
+  under `~/.claude/projects/<project-slug>/<session_id>.jsonl`. The
+  file is authoritative for session content; agentpulse treats it as
+  external.
+- `tool_input` and `tool_response` shapes vary per tool. For `Bash`:
+  `{"command", "description"}` in; `{"stdout", "stderr", "interrupted",
+  "isImage", "noOutputExpected"}` out. For other tools, the shape
+  follows Claude's tool spec.
+- `permission_mode` values observed: `default`, `acceptEdits`, `plan`,
+  `bypassPermissions`. Claude Code may add more.
+
+## Emission cadence
+
+- Fires once per hook event. Tool events fire before and after each
+  tool call. `UserPromptSubmit` fires when the user sends a message.
+  `Stop` fires when Claude finishes a turn. `SubagentStart`/`Stop`
+  bracket each subagent invocation.
+- Non-retrying on relay-side failure; a hook POST that fails is
+  dropped. Claude Code itself does not re-invoke the hook.
+- Relay timeout: 2 seconds per POST.

--- a/docs/statusline-payload.md
+++ b/docs/statusline-payload.md
@@ -1,0 +1,108 @@
+# Statusline Relay Payload
+
+Reference: what the statusline relay
+(`~/.claude/my-claude-stuff/scripts/statusline.py`) emits when POSTing to
+`/statusline/claude`. Purely the wire shape — not what any consumer does
+with it.
+
+The relay script is external to this repo (lives in the user's personal
+dotfiles). This doc is the pinned reference so we don't have to re-read
+it.
+
+## Upstream reference
+
+Anthropic's statusline documentation is the authoritative source for
+Claude-Code-native fields: **https://code.claude.com/docs/en/statusline**.
+Anthropic does not publish a formal JSON Schema — the docs are prose
+with examples. Treat the fields documented below as the working set;
+new fields may appear in future Claude Code releases and will land in
+`raw_payload` before the schema catches up.
+
+## Example payload
+
+```json
+{
+  "session_id": "uuid",
+  "pid": 12345,
+  "source_system": "host.example",
+  "transcript_path": "C:\\Users\\...\\<session>.jsonl",
+  "cwd": "/path/to/project",
+  "workspace": {
+    "project_dir": "/path/to/project",
+    "current_dir": "/path/to/project",
+    "added_dirs": ["..."]
+  },
+  "model": {
+    "id": "claude-opus-4-7[1m]",
+    "display_name": "Opus 4.7 (1M context)"
+  },
+  "version": "2.1.117",
+  "cost": {
+    "total_cost_usd": 5.25,
+    "total_duration_ms": 120000,
+    "total_api_duration_ms": 30000,
+    "total_lines_added": 100,
+    "total_lines_removed": 20
+  },
+  "context_window": {
+    "total_input_tokens": 10000,
+    "total_output_tokens": 50000,
+    "context_window_size": 1000000,
+    "current_usage": {
+      "input_tokens": 5,
+      "output_tokens": 200,
+      "cache_creation_input_tokens": 500,
+      "cache_read_input_tokens": 9000
+    },
+    "used_percentage": 25,
+    "remaining_percentage": 75
+  },
+  "exceeds_200k_tokens": false,
+  "rate_limits": {
+    "five_hour": {"used_percentage": 3, "resets_at": 1776920400},
+    "seven_day": {"used_percentage": 71, "resets_at": 1776981600}
+  },
+  "output_style": {"name": "default"}
+}
+```
+
+## Field origin
+
+| Source | Fields |
+|---|---|
+| Claude Code (native) | `session_id`, `transcript_path`, `cwd`, `workspace`, `model`, `version`, `cost`, `context_window`, `exceeds_200k_tokens`, `rate_limits`, `output_style` |
+| Relay-injected | `pid`, `source_system` |
+
+### Relay-injected fields
+
+| Field | Type | Computation |
+|---|---|---|
+| `source_system` | string | `platform.node()` — hostname of the machine running Claude Code |
+| `pid` | int | Claude Code's PID. Relay walks `psutil.Process(os.getpid()).parents()` and returns the first ancestor whose process name contains `"claude"`. Falls back to `os.getppid()` if psutil is unavailable or no match. |
+
+## Semantic notes
+
+- `cost.total_cost_usd` is **cumulative over the Claude process lifetime**,
+  not per-session. It persists across `/clear` inside one process and
+  resets to zero on `claude --resume` into a new process. Consequence:
+  across a session_id that spans two process lifetimes (resume), the
+  series is not monotonic — see the resume/reset findings in project
+  memory and prior debugging sessions.
+- `pid` can change within a single `session_id` if the user resumes the
+  session from a new process. Each POST carries the pid that was current
+  at the moment of the POST.
+- `workspace.project_dir`, `workspace.current_dir`, and the top-level
+  `cwd` can diverge. The statusline code that renders the "project"
+  cost uses `workspace.project_dir`.
+- `rate_limits.*.resets_at` is a Unix epoch *second* (integer), not an
+  ISO string. Distinct from `claude_limits.raw_response.*.resets_at`
+  from the OAuth API, which is an ISO-8601 string.
+
+## Emission cadence
+
+- Fires once per statusline render, which Claude Code triggers after
+  each tool call and on some input events. Observed rate on an active
+  session: roughly once per few seconds during turns, zero while idle.
+- Never fires while Claude is waiting for user input between turns.
+- Non-retrying on relay-side failure; a statusline post that fails is
+  dropped.


### PR DESCRIPTION
Capture the future-state data architecture and the wire-format of
Claude Code's native feeds so we don't have to re-derive either.

- docs/database.md -- current schema reference with ER diagrams
  per table, relationships, writing conventions, and known
  limitations of the single-row-per-session model.
- docs/database-proposed.md -- append-only data model: log tables
  only (claude_log_hooks, claude_log_statuslines,
  claude_log_pid_deaths, claude_log_api_limits), surrogate id PKs,
  composite UK identifying the actor, REAL-seconds time
  normalization, received_at/received_by and observed_at/observed_by
  audit pairs, and a single-account design constraint.
- docs/hooks-payload.md -- wire reference for hook_relay.py POSTs,
  including relay-injected pid/source_system and per-event-type
  field additions.
- docs/statusline-payload.md -- wire reference for the external
  statusline relay, flagging cost_usd's per-process-lifetime
  semantics.
- docs/clients.md -- update client guide to the process-centric
  response model with cost_by_day replacing prior_cost_usd.

Assisted-by: Claude Code (Claude Opus 4.7 (1M context))
