### PR TITLE
feat(v2): add session cost fields to statusline_logged broadcast

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,13 @@ have `session_id`.
   dispatch on `event_name` (`SessionStart`, `PreToolUse`, `Stop`, etc.)
   for the typed signal they want.
 - `statusline_logged` — every row in `claude_log_statuslines`. Cost,
-  context, model, etc., plus derived ids and `log_id`.
+  context, model, etc., plus derived ids and `log_id`. Includes
+  `session_total_cost_usd` (server-derived sum across all instance
+  windows in the session, including this row) and
+  `session_today_cost_usd` (the today portion in server local time)
+  so clients can update per-session totals live without REST refetch
+  when `cost_usd` resets on `claude --resume`. The full `cost_by_day`
+  map is **not** on the wire — fetch from REST on a coarse cadence.
 - `pid_death_logged` — every row in `claude_log_pid_deaths`.
   Process-scoped (no session_id/epoch_id). Client action: mark every
   session under `process_id` as ended.

--- a/docs/design/clients.md
+++ b/docs/design/clients.md
@@ -120,14 +120,32 @@ process's `cost_usd`, `total_input_tokens`, `total_output_tokens`,
 `lines_added`, `lines_removed`. Replace the session's
 `context_used_pct` and `model_name`.
 
-`cost_usd` is **process-cumulative**, not session-cumulative.
+`cost_usd` is **process-cumulative**, not session-cumulative — it
+resets to $0 in a new pid after `claude --resume`.
 
-`cost_by_day` is **not on the wire** — it's derived. If you need
-daily breakdown, GET the process body on a coarse cadence:
+`session_total_cost_usd` is the **session-cumulative** total derived
+server-side (sum across all instance windows in the session,
+including this row). Replace the session's running total with this
+value — no client-side aggregation, no REST refetch on resume. Same
+field as `SessionResponse.total_cost_usd` from REST.
+
+`session_today_cost_usd` is **today's bucket** (server local time)
+of the session cost. Same value the client would derive by plucking
+today's key from `cost_by_day` on REST. Drives the "spend so far
+today" indicator without forcing the client to track yesterday's
+total or refetch at midnight.
+
+`cost_by_day` is **not on the wire** — sending the full map on every
+statusline would grow unbounded for long-running sessions. If you
+need historical breakdown, refetch on a coarse cadence:
 
 ```
-GET /api/v2/processes/{process_id}    # has cost_by_day
+GET /api/v2/sessions/{session_id}     # has cost_by_day
+GET /api/v2/processes/{process_id}    # has cost_by_day for the process
 ```
+
+A reasonable cadence is once per day shortly after midnight — that's
+when yesterday's bucket finalizes and a new today bucket appears.
 
 A `statusline_logged` may arrive for a session_id with no prior
 `hook_logged` (statusline can race ahead of hooks). Create a
@@ -248,6 +266,9 @@ server logs them, doesn't broadcast). The
 
 - **Don't accumulate `cost_usd`** across `statusline_logged`
   frames. It's cumulative; replace.
+- **Don't sum `cost_usd` across processes** to get a session total.
+  Use `session_total_cost_usd` from the same frame — the server
+  already did the instance-windowed aggregation correctly.
 - **Don't compute `process_id` yourself.** It's an opaque
   server-derived hash. Echo what the server gives you.
 - **Don't rely on `event_name` for cleanup.** When

--- a/docs/design/websocket.md
+++ b/docs/design/websocket.md
@@ -167,6 +167,8 @@ the `StatuslineResponse` REST projection (`api.md`) plus envelope.
   "model_name": "Opus 4.7 (1M context)",
   "claude_version": "2.1.117",
   "cost_usd": 83.58,
+  "session_total_cost_usd": 142.91,
+  "session_today_cost_usd": 12.34,
   "total_input_tokens": 292478,
   "total_output_tokens": 512427,
   "context_used_pct": 6,
@@ -189,10 +191,24 @@ Important behaviors:
 - **`cost_usd` is process-cumulative**, not session-cumulative.
   Persists across `/clear` within one process, resets on
   `claude --resume` into a new process.
-- **No `cost_by_day` field on this message.** Daily breakdown is a
-  derived view available at `GET /api/v2/processes/{process_id}`
-  (in the process body). Clients that need daily totals refetch on
-  a coarse cadence; the per-statusline broadcast stays small.
+- **`session_total_cost_usd` is server-derived.** Sum of MAX(`cost_usd`)
+  per process instance in the session, including this row. Lets
+  clients update per-session totals live without a REST round-trip
+  after a resume resets `cost_usd` to $0 in the new pid. Same value
+  the REST `SessionResponse.total_cost_usd` carries — derivation
+  lives in one place server-side.
+- **`session_today_cost_usd` is the today (server local time) bucket**
+  of the same derivation — equivalent to plucking today's key out of
+  `cost_by_day` on the REST `SessionResponse`. Carried as a scalar
+  because today is the only bucket that moves between consecutive
+  statuslines; broadcasting the full historical map would grow
+  unbounded over a long-running session and re-send mostly stale
+  data.
+- **No `cost_by_day` map on this message.** Full daily breakdown is
+  a derived view available at `GET /api/v2/sessions/{id}` (and
+  `GET /api/v2/processes/{process_id}` for the process variant).
+  Clients that need history refetch on a coarse cadence (e.g. once
+  per day at midnight); live updates use `session_today_cost_usd`.
 - **Always broadcast.** A statusline whose `session_id` doesn't yet
   match any hook is still a valid log row and produces a broadcast.
   Consumers tracking sessions by `session_id` may receive a

--- a/src/agentpulse/api/v2/events.py
+++ b/src/agentpulse/api/v2/events.py
@@ -154,6 +154,8 @@ async def broadcast_statusline_logged(
     model_name: str | None,
     claude_version: str | None,
     cost_usd: float | None,
+    session_total_cost_usd: float,
+    session_today_cost_usd: float,
     total_input_tokens: int | None,
     total_output_tokens: int | None,
     context_used_pct: float | None,
@@ -168,7 +170,20 @@ async def broadcast_statusline_logged(
     received_at: float,
     received_by: str,
 ) -> None:
-    """One row in claude_log_statuslines → one frame on /ws/v2."""
+    """One row in claude_log_statuslines → one frame on /ws/v2.
+
+    `session_total_cost_usd` is server-derived (sum of MAX(cost_usd) per
+    process instance in the session, including this row). Lets clients
+    update the per-session total live without re-fetching REST after a
+    `claude --resume` resets the per-process `cost_usd` counter.
+
+    `session_today_cost_usd` is the today (server local time) bucket of
+    the same derivation — same value the client would get by plucking
+    today's key out of `cost_by_day` on the REST `SessionResponse`. The
+    full daily map is intentionally NOT on the wire (unbounded growth
+    for long-running sessions); today's scalar is the only bucket that
+    moves between consecutive statuslines.
+    """
     logger.debug("broadcast statusline_logged log_id=%d session=%s", log_id, session_id)
     await manager.broadcast(
         {
@@ -186,6 +201,8 @@ async def broadcast_statusline_logged(
             "model_name": model_name,
             "claude_version": claude_version,
             "cost_usd": cost_usd,
+            "session_total_cost_usd": session_total_cost_usd,
+            "session_today_cost_usd": session_today_cost_usd,
             "total_input_tokens": total_input_tokens,
             "total_output_tokens": total_output_tokens,
             "context_used_pct": context_used_pct,

--- a/src/agentpulse/api/v2/queries/__init__.py
+++ b/src/agentpulse/api/v2/queries/__init__.py
@@ -25,6 +25,8 @@ from agentpulse.api.v2.queries.sessions import (
     get_session_by_id,
     get_session_epochs,
     get_sessions,
+    session_today_cost,
+    session_total_cost,
 )
 
 __all__ = [
@@ -38,4 +40,6 @@ __all__ = [
     "get_session_by_id",
     "get_session_epochs",
     "get_sessions",
+    "session_today_cost",
+    "session_total_cost",
 ]

--- a/src/agentpulse/api/v2/queries/sessions.py
+++ b/src/agentpulse/api/v2/queries/sessions.py
@@ -242,7 +242,7 @@ async def _derive_session(db: aiosqlite.Connection, *, session_id: str) -> dict 
     row = await cursor.fetchone()
     epoch_count = int(row["n"]) if row else 0
 
-    total_cost_usd = await _session_total_cost(db, session_id=session_id)
+    total_cost_usd = await session_total_cost(db, session_id=session_id)
     cost_by_day = await _session_cost_by_day(db, session_id=session_id)
 
     return {
@@ -313,13 +313,17 @@ async def _session_process_instances(
     return instances
 
 
-async def _session_total_cost(db: aiosqlite.Connection, *, session_id: str) -> float:
+async def session_total_cost(db: aiosqlite.Connection, *, session_id: str) -> float:
     """Sum of MAX(cost_usd) per process instance in the session.
 
     Instance-windowed grouping handles PID reuse: a tuple that died and was
     reused yields two instances, each contributing its own MAX. Without
     windowing, one MAX would capture only the higher of the two counters
     and silently undercount the session total.
+
+    Public so the statusline broadcast path can compute the same derived
+    value the REST `SessionResponse.total_cost_usd` carries — keeps the
+    derivation in one place.
     """
     instances = await _session_process_instances(db, session_id=session_id)
     total = 0.0
@@ -350,6 +354,22 @@ async def _session_total_cost(db: aiosqlite.Connection, *, session_id: str) -> f
         if row is not None and row["m"] is not None:
             total += float(row["m"])
     return round(total, 6)
+
+
+async def session_today_cost(db: aiosqlite.Connection, *, session_id: str) -> float:
+    """Today's portion of the session cost (server local time).
+
+    Same value the client would derive by plucking today's key out of
+    `cost_by_day` on the REST `SessionResponse`. Public so the statusline
+    broadcast can carry the live "today" scalar without forcing clients
+    to track yesterday's total themselves or refetch REST at midnight.
+
+    Returns 0.0 when the session has no cost data yet today.
+    """
+    from datetime import date
+
+    by_day = await _session_cost_by_day(db, session_id=session_id)
+    return by_day.get(date.today().isoformat(), 0.0)
 
 
 async def _session_cost_by_day(

--- a/src/agentpulse/platforms/claude/hooks.py
+++ b/src/agentpulse/platforms/claude/hooks.py
@@ -13,7 +13,7 @@ from agentpulse.api.v2.events import (
     broadcast_hook_logged,
     broadcast_statusline_logged,
 )
-from agentpulse.api.v2.queries import IdEnricher
+from agentpulse.api.v2.queries import IdEnricher, session_today_cost, session_total_cost
 from agentpulse.db import get_db
 from agentpulse.events import (
     broadcast_hook_event,
@@ -386,6 +386,12 @@ async def receive_statusline(body: dict, request: Request) -> dict:
             source_system=source_system,
             cwd=cwd,
         )
+        # Derived session totals — computed *after* the v2 insert so they
+        # include this row. Lets clients update per-session cost live
+        # without a REST round-trip after `claude --resume` resets the
+        # per-process `cost_usd` to $0 in the new pid.
+        session_total = await session_total_cost(db, session_id=session_id)
+        session_today = await session_today_cost(db, session_id=session_id)
         await broadcast_statusline_logged(
             log_id=v2_log_id,
             process_id=process_id,
@@ -399,6 +405,8 @@ async def receive_statusline(body: dict, request: Request) -> dict:
             model_name=model_name,
             claude_version=body.get("version") or None,
             cost_usd=cost_usd,
+            session_total_cost_usd=session_total,
+            session_today_cost_usd=session_today,
             total_input_tokens=total_input_tokens,
             total_output_tokens=total_output_tokens,
             context_used_pct=context_used_pct,

--- a/tests/api/v2/test_websocket.py
+++ b/tests/api/v2/test_websocket.py
@@ -178,6 +178,8 @@ class TestStatuslineLoggedBroadcast:
             assert frame["model_name"] == "Opus 4.7 (1M context)"
             assert frame["claude_version"] == "2.1.117"
             assert frame["cost_usd"] == 1.25
+            assert frame["session_total_cost_usd"] == pytest.approx(1.25)
+            assert frame["session_today_cost_usd"] == pytest.approx(1.25)
             assert frame["duration_seconds"] == 60.0
             assert frame["api_duration_seconds"] == 12.0
             assert frame["cache_read_tokens"] == 800
@@ -187,6 +189,69 @@ class TestStatuslineLoggedBroadcast:
             assert isinstance(frame["epoch_id"], str) and len(frame["epoch_id"]) == 16
             assert frame["log_id"] == 1
             assert "raw_payload" not in frame
+
+    def test_session_total_cost_usd_sums_across_processes(self, client) -> None:
+        """The broadcast carries the derived session-wide total, not just
+        this process's cost_usd. Lets clients update session totals live
+        without re-fetching REST after a `claude --resume` into a new pid.
+        """
+        # First statusline: pid=10, cost=2.0 → session total = 2.0
+        first = {
+            "session_id": "s1",
+            "pid": 10,
+            "source_system": "host",
+            "cwd": "/proj",
+            "cost": {"total_cost_usd": 2.0},
+        }
+        # Second statusline: same session, new pid (resume), cost=1.5 →
+        # session total = 2.0 + 1.5 = 3.5
+        second = {
+            "session_id": "s1",
+            "pid": 20,
+            "source_system": "host",
+            "cwd": "/proj",
+            "cost": {"total_cost_usd": 1.5},
+        }
+        with client.websocket_connect("/ws/v2") as ws:
+            client.post("/statusline/claude", json=first)
+            frame1 = ws.receive_json()
+            assert frame1["cost_usd"] == 2.0
+            assert frame1["session_total_cost_usd"] == pytest.approx(2.0)
+
+            client.post("/statusline/claude", json=second)
+            frame2 = ws.receive_json()
+            assert frame2["cost_usd"] == 1.5
+            assert frame2["session_total_cost_usd"] == pytest.approx(3.5)
+
+    def test_session_today_cost_usd_tracks_today_bucket(self, client) -> None:
+        """`session_today_cost_usd` is just the today portion of the session
+        total — same value the client would derive by plucking today's
+        key from `cost_by_day` on REST. Two same-day statuslines into
+        different processes should sum their today contribution.
+        """
+        first = {
+            "session_id": "s1",
+            "pid": 10,
+            "source_system": "host",
+            "cwd": "/proj",
+            "cost": {"total_cost_usd": 2.0},
+        }
+        second = {
+            "session_id": "s1",
+            "pid": 20,
+            "source_system": "host",
+            "cwd": "/proj",
+            "cost": {"total_cost_usd": 1.5},
+        }
+        with client.websocket_connect("/ws/v2") as ws:
+            client.post("/statusline/claude", json=first)
+            frame1 = ws.receive_json()
+            assert frame1["session_today_cost_usd"] == pytest.approx(2.0)
+
+            client.post("/statusline/claude", json=second)
+            frame2 = ws.receive_json()
+            # Both statuslines arrive same wall-clock day on the server
+            assert frame2["session_today_cost_usd"] == pytest.approx(3.5)
 
     def test_pidless_statusline_does_not_broadcast(self, client) -> None:
         no_pid = {


### PR DESCRIPTION
Statusline broadcasts now carry the derived session-cumulative cost so
clients can update per-session totals live. Without this, a `claude
--resume` into a new pid resets `cost_usd` to $0 in the next frame and
clients have no live signal of the session's true running spend short
of refetching REST.

- `session_total_cost_usd`: sum of MAX(`cost_usd`) per process instance
  in the session, including this row. Same value REST's
  `SessionResponse.total_cost_usd` carries.
- `session_today_cost_usd`: today (server local time) bucket of the
  same derivation. Carried as a scalar — broadcasting the full
  `cost_by_day` map would grow unbounded for long-running sessions and
  re-send mostly stale data on every statusline.
- Promoted `_session_total_cost` to public `session_total_cost`; added
  `session_today_cost` plucking today's key from the existing per-day
  derivation. Single source of truth between REST and broadcast.

Documented in `docs/design/websocket.md`, `docs/design/clients.md`,
and `CLAUDE.md`.

Assisted-by: Claude Code (Claude Opus 4.7 (1M context))
