### PR TITLE
feat(v2): add order param to /log/* and fix /limits doc drift

### DIFF
--- a/docs/design/api.md
+++ b/docs/design/api.md
@@ -97,9 +97,15 @@ opaque.
 | GET    | `/api/v2/agents/{agent_id}` | Agent detail. |
 | GET    | `/api/v2/agents/{agent_id}/events` | Hook events scoped to one agent. |
 | POST   | `/api/v2/sessions/{session_id}/clear` | Insert a synthetic `clear_state` row in `claude_log_hooks` and broadcast `session_cleared`. Used when Claude is interrupted with no events firing. |
-| GET    | `/api/v2/limits` | Latest cached usage-limits snapshot. 404 when disabled or unavailable. |
-| GET    | `/api/v2/limits/history` | Historical limits snapshots. Pagination as above. |
 | GET    | `/api/v2/summary` | Aggregate stats across the running deployment. |
+
+For usage limits, query the raw log endpoint
+`/api/v2/log/api-limits` directly: `?order=desc&limit=1` returns the
+latest snapshot; default `order=asc` returns paginated history
+oldest-first. Account-scoped, no identity filters.
+
+All `/api/v2/log/*` endpoints accept `order=asc|desc` (default `asc`)
+to control row direction. Use `desc` whenever you want newest-first.
 
 ### Raw log streams
 
@@ -359,31 +365,32 @@ Mirrors `claude_log_statuslines` columns one-to-one (plus derived
 }
 ```
 
-### `LimitsResponse` (`/limits`)
+### `ApiLimitsResponse` (`claude_log_api_limits` projection)
 
 ```json
 {
-  "available": true,
-  "fetched_at": 1776052424.367,
-  "age_seconds": 0.0,
-  "stale": false,
-  "refresh_after": 1776052544.367,
-  "five_hour": {
-    "utilization": 11.0,
-    "resets_at_seconds": 1776920400.0,
-    "resets_at": "2026-04-13T07:00:00+00:00"
-  },
-  "seven_day": {
-    "utilization": 8.0,
-    "resets_at_seconds": 1776981600.0,
-    "resets_at": "2026-04-19T13:00:00+00:00"
-  }
+  "id": 27,
+  "platform": "claude",
+  "received_at": 1776052424.367,
+  "received_by": "limits-fetcher",
+  "five_hour_utilization": 11.0,
+  "five_hour_resets_at": 1776920400.0,
+  "seven_day_utilization": 8.0,
+  "seven_day_resets_at": 1776981600.0,
+  "raw_response": "{...}"
 }
 ```
 
-Both `resets_at_seconds` (epoch seconds, our standard unit) and the
-upstream ISO string `resets_at` (passthrough from the OAuth API) are
-returned. Clients should prefer `resets_at_seconds`.
+Fields are the row's columns from `claude_log_api_limits`.
+`*_resets_at` values are Unix epoch seconds (the upstream OAuth API
+returns ISO strings; the inserter normalizes on write). Other
+buckets the broadcast doesn't promote (`seven_day_opus`,
+`seven_day_sonnet`, `extra_usage`) live in `raw_response` only —
+parse there when needed.
+
+Clients computing "is this stale?" derive it from
+`now() - received_at` against whatever freshness threshold they
+need; the row carries no derived staleness fields.
 
 ### `SummaryResponse`
 
@@ -394,7 +401,7 @@ returned. Clients should prefer `resets_at_seconds`.
   "active_agents": 5,
   "active_epochs": 4,
   "state_breakdown": {"working": 2, "idle": 1},
-  "limits": { /* LimitsResponse, or null */ }
+  "limits": { /* ApiLimitsResponse, or null */ }
 }
 ```
 

--- a/docs/design/clients.md
+++ b/docs/design/clients.md
@@ -44,7 +44,7 @@ For the upstream Claude Code semantics behind these, see
 ```
 1. Open WebSocket /ws/v2. Buffer frames; don't process yet.
 2. GET /api/v2/processes?active=true   → live processes (sessions nested)
-3. GET /api/v2/limits                  → optional, if you display them
+3. GET /api/v2/log/api-limits?order=desc&limit=1  → optional, if you display them (latest row)
 4. Apply buffered frames + subsequent live frames.
 ```
 
@@ -188,7 +188,7 @@ Less commonly:
 | Drill into one session | `GET /api/v2/sessions/{session_id}` (epochs + agents nested) |
 | Show event history | `GET /api/v2/sessions/{session_id}/events?limit=N` |
 | Show statusline history | `GET /api/v2/sessions/{session_id}/statuslines?limit=N` |
-| Show usage limits | `GET /api/v2/limits` |
+| Show usage limits | `GET /api/v2/log/api-limits?order=desc&limit=1` (latest row) |
 | Reset a stuck session | `POST /api/v2/sessions/{session_id}/clear` |
 
 `POST /sessions/{id}/clear` is the only mutation you'll call. Use
@@ -258,9 +258,9 @@ Display it tentatively; populate the rest on the first
 `api_limits_logged` only fires on successful fetches. If you care
 about staleness, watch the gap between consecutive
 `received_at` values; long gaps may mean fetcher failures (the
-server logs them, doesn't broadcast). The
-[REST `/api/v2/limits`](api.md) response carries `stale` and
-`age_seconds` for explicit checking.
+server logs them, doesn't broadcast). The REST endpoint
+[`/api/v2/log/api-limits?order=desc&limit=1`](api.md) returns the latest row;
+derive staleness as `now() - received_at`.
 
 ## Don't do
 

--- a/docs/design/ux.md
+++ b/docs/design/ux.md
@@ -88,8 +88,8 @@ also broadcasts one `api_limits_logged` WebSocket frame.
 
 When `fetch_limits` is false, the loop is fully inert: no OAuth
 token is read, no API call is made, no row is written. Clients see
-404 / 503 from `/api/v2/limits` and no `api_limits_logged`
-broadcasts.
+empty results from `/api/v2/log/api-limits` and no
+`api_limits_logged` broadcasts.
 
 ### Producer principles
 
@@ -118,7 +118,7 @@ A new consumer wants the current state of the world.
 3. **Optional drilldowns** if the client renders detail:
    - `GET /api/v2/processes/{process_id}` — sessions, epochs nested
    - `GET /api/v2/sessions/{session_id}` — agents, epochs nested
-4. **Optional limits**: `GET /api/v2/limits`.
+4. **Optional limits**: `GET /api/v2/log/api-limits?order=desc&limit=1` (latest row).
 5. **Apply buffered frames + subsequent live frames**.
 
 The "buffer then drain" pattern avoids the race where a frame

--- a/docs/design/websocket.md
+++ b/docs/design/websocket.md
@@ -265,8 +265,9 @@ account** constraint in `database.md`).
 ```
 
 `*_resets_at` values are seconds. The full upstream response is
-available at `GET /api/v2/limits/history` with `include=raw` when a
-client wants the buckets we don't promote (e.g. `seven_day_opus`).
+available at `GET /api/v2/log/api-limits` (rows include
+`raw_response`) when a client wants the buckets we don't promote
+(e.g. `seven_day_opus`).
 
 This is the only message type with no `process_id` — limits are
 account-scoped, not process-scoped.
@@ -277,7 +278,7 @@ account-scoped, not process-scoped.
 2. Buffer incoming frames.
 3. `GET /api/v2/processes?active=true` — initial process list with
    nested sessions.
-4. `GET /api/v2/limits` if interested.
+4. `GET /api/v2/log/api-limits?order=desc&limit=1` if interested (latest row).
 5. Apply buffered + subsequent broadcasts.
 
 ## Reconnect pattern

--- a/src/agentpulse/api/v2/queries/log.py
+++ b/src/agentpulse/api/v2/queries/log.py
@@ -21,6 +21,20 @@ def _build_where(filters: list[tuple[str, object]]) -> tuple[str, list[object]]:
     return where, params
 
 
+def _order_clause(order: str) -> str:
+    """Validate `order` and return the SQL fragment for ORDER BY id.
+
+    SQL ORDER BY direction can't be parameterized — the value is
+    interpolated into the query string. Strict whitelist guards
+    against injection.
+    """
+    if order == "asc":
+        return "ORDER BY id ASC"
+    if order == "desc":
+        return "ORDER BY id DESC"
+    raise ValueError(f"order must be 'asc' or 'desc', got {order!r}")
+
+
 async def get_log_hooks(
     db: aiosqlite.Connection,
     *,
@@ -35,8 +49,10 @@ async def get_log_hooks(
     tool_name: str | None = None,
     limit: int = 100,
     offset: int = 0,
+    order: str = "asc",
 ) -> list[dict]:
-    """Filtered + paginated read of claude_log_hooks. Ordered by id ASC."""
+    """Filtered + paginated read of claude_log_hooks. Ordered by id; pass
+    `order="desc"` for newest-first."""
     where, params = _build_where(
         [
             ("received_at >= ?", since),
@@ -50,7 +66,10 @@ async def get_log_hooks(
             ("tool_name = ?", tool_name),
         ]
     )
-    sql = f"SELECT * FROM claude_log_hooks {where} ORDER BY id LIMIT ? OFFSET ?"
+    sql = (
+        f"SELECT * FROM claude_log_hooks {where} {_order_clause(order)} "
+        f"LIMIT ? OFFSET ?"
+    )
     cursor = await db.execute(sql, [*params, limit, offset])
     rows = await cursor.fetchall()
     return [dict(r) for r in rows]
@@ -67,8 +86,10 @@ async def get_log_statuslines(
     cwd: str | None = None,
     limit: int = 100,
     offset: int = 0,
+    order: str = "asc",
 ) -> list[dict]:
-    """Filtered + paginated read of claude_log_statuslines. Ordered by id ASC."""
+    """Filtered + paginated read of claude_log_statuslines. Ordered by id;
+    pass `order="desc"` for newest-first."""
     where, params = _build_where(
         [
             ("received_at >= ?", since),
@@ -79,7 +100,10 @@ async def get_log_statuslines(
             ("cwd = ?", cwd),
         ]
     )
-    sql = f"SELECT * FROM claude_log_statuslines {where} ORDER BY id LIMIT ? OFFSET ?"
+    sql = (
+        f"SELECT * FROM claude_log_statuslines {where} {_order_clause(order)} "
+        f"LIMIT ? OFFSET ?"
+    )
     cursor = await db.execute(sql, [*params, limit, offset])
     rows = await cursor.fetchall()
     return [dict(r) for r in rows]
@@ -95,8 +119,10 @@ async def get_log_pid_deaths(
     cwd: str | None = None,
     limit: int = 100,
     offset: int = 0,
+    order: str = "asc",
 ) -> list[dict]:
-    """Filtered + paginated read of claude_log_pid_deaths. Ordered by id ASC.
+    """Filtered + paginated read of claude_log_pid_deaths. Ordered by id;
+    pass `order="desc"` for newest-first.
 
     Time bounds apply to observed_at (the watcher-observation timestamp),
     not received_at — pid-deaths are observation-sourced, not wire-sourced.
@@ -110,7 +136,10 @@ async def get_log_pid_deaths(
             ("cwd = ?", cwd),
         ]
     )
-    sql = f"SELECT * FROM claude_log_pid_deaths {where} ORDER BY id LIMIT ? OFFSET ?"
+    sql = (
+        f"SELECT * FROM claude_log_pid_deaths {where} {_order_clause(order)} "
+        f"LIMIT ? OFFSET ?"
+    )
     cursor = await db.execute(sql, [*params, limit, offset])
     rows = await cursor.fetchall()
     return [dict(r) for r in rows]
@@ -123,8 +152,11 @@ async def get_log_api_limits(
     until: float | None = None,
     limit: int = 100,
     offset: int = 0,
+    order: str = "asc",
 ) -> list[dict]:
-    """Filtered + paginated read of claude_log_api_limits. Ordered by id ASC.
+    """Filtered + paginated read of claude_log_api_limits. Ordered by id;
+    pass `order="desc"` for newest-first (use `order=desc&limit=1` to fetch
+    the latest snapshot).
 
     Account-scoped — no pid/source_system/cwd filters. since/until bound
     received_at.
@@ -135,7 +167,10 @@ async def get_log_api_limits(
             ("received_at <= ?", until),
         ]
     )
-    sql = f"SELECT * FROM claude_log_api_limits {where} ORDER BY id LIMIT ? OFFSET ?"
+    sql = (
+        f"SELECT * FROM claude_log_api_limits {where} {_order_clause(order)} "
+        f"LIMIT ? OFFSET ?"
+    )
     cursor = await db.execute(sql, [*params, limit, offset])
     rows = await cursor.fetchall()
     return [dict(r) for r in rows]

--- a/src/agentpulse/api/v2/router.py
+++ b/src/agentpulse/api/v2/router.py
@@ -198,6 +198,7 @@ async def list_log_hooks(
     tool_name: str | None = None,
     limit: int = Query(default=100, ge=1, le=1000),
     offset: int = Query(default=0, ge=0),
+    order: str = Query(default="asc", pattern="^(asc|desc)$"),
 ) -> list[EventResponse]:
     db = await get_db()
     rows = await queries.get_log_hooks(
@@ -213,6 +214,7 @@ async def list_log_hooks(
         tool_name=tool_name,
         limit=limit,
         offset=offset,
+        order=order,
     )
     enricher = queries.IdEnricher(db)
     out: list[EventResponse] = []
@@ -264,6 +266,7 @@ async def list_log_statuslines(
     cwd: str | None = None,
     limit: int = Query(default=100, ge=1, le=1000),
     offset: int = Query(default=0, ge=0),
+    order: str = Query(default="asc", pattern="^(asc|desc)$"),
 ) -> list[StatuslineResponse]:
     db = await get_db()
     rows = await queries.get_log_statuslines(
@@ -276,6 +279,7 @@ async def list_log_statuslines(
         cwd=cwd,
         limit=limit,
         offset=offset,
+        order=order,
     )
     enricher = queries.IdEnricher(db)
     out: list[StatuslineResponse] = []
@@ -337,6 +341,7 @@ async def list_log_pid_deaths(
     cwd: str | None = None,
     limit: int = Query(default=100, ge=1, le=1000),
     offset: int = Query(default=0, ge=0),
+    order: str = Query(default="asc", pattern="^(asc|desc)$"),
 ) -> list[PidDeathResponse]:
     """Raw read of claude_log_pid_deaths. since/until bound observed_at."""
     db = await get_db()
@@ -349,6 +354,7 @@ async def list_log_pid_deaths(
         cwd=cwd,
         limit=limit,
         offset=offset,
+        order=order,
     )
     enricher = queries.IdEnricher(db)
     out: list[PidDeathResponse] = []
@@ -385,14 +391,16 @@ async def list_log_api_limits(
     until: float | None = None,
     limit: int = Query(default=100, ge=1, le=1000),
     offset: int = Query(default=0, ge=0),
+    order: str = Query(default="asc", pattern="^(asc|desc)$"),
 ) -> list[ApiLimitsResponse]:
     """Raw read of claude_log_api_limits. Account-scoped — no identity filters.
 
     since/until bound received_at. raw_response is included by default.
+    Use `order=desc&limit=1` to fetch the latest snapshot.
     """
     db = await get_db()
     rows = await queries.get_log_api_limits(
-        db, since=since, until=until, limit=limit, offset=offset
+        db, since=since, until=until, limit=limit, offset=offset, order=order
     )
     return [
         ApiLimitsResponse(

--- a/tests/api/v2/test_log_api_limits_endpoint.py
+++ b/tests/api/v2/test_log_api_limits_endpoint.py
@@ -86,3 +86,34 @@ class TestLogApiLimitsEndpoint:
     def test_invalid_limit_returns_422(self, client) -> None:
         resp = client.get("/api/v2/log/api-limits?limit=2000")
         assert resp.status_code == 422
+
+    def test_order_desc_returns_newest_first(self, client, db) -> None:
+        for t in (100.0, 200.0, 300.0):
+            _seed_api_limits(db, received_at=t)
+
+        resp = client.get("/api/v2/log/api-limits?order=desc")
+        body = resp.json()
+        assert [r["received_at"] for r in body] == [300.0, 200.0, 100.0]
+
+    def test_order_desc_with_limit_one_returns_latest(self, client, db) -> None:
+        """The pattern docs recommend for `latest snapshot` reads."""
+        for t in (100.0, 200.0, 300.0):
+            _seed_api_limits(db, received_at=t)
+
+        resp = client.get("/api/v2/log/api-limits?order=desc&limit=1")
+        body = resp.json()
+        assert len(body) == 1
+        assert body[0]["received_at"] == 300.0
+
+    def test_order_asc_default_unchanged(self, client, db) -> None:
+        """Default behavior stays asc — no breaking change for existing clients."""
+        for t in (100.0, 200.0, 300.0):
+            _seed_api_limits(db, received_at=t)
+
+        resp = client.get("/api/v2/log/api-limits")
+        body = resp.json()
+        assert [r["received_at"] for r in body] == [100.0, 200.0, 300.0]
+
+    def test_invalid_order_returns_422(self, client) -> None:
+        resp = client.get("/api/v2/log/api-limits?order=sideways")
+        assert resp.status_code == 422


### PR DESCRIPTION
All `/api/v2/log/*` endpoints (`hooks`, `statuslines`, `pid-deaths`,
`api-limits`) now accept `order=asc|desc` (default `asc` — no
behavior change for existing callers). Pattern-validated by FastAPI;
SQL direction is interpolated through a strict whitelist.
`order=desc&limit=1` is now the canonical "fetch latest snapshot"
shape — particularly for the limits endpoint where there's no
nicer alternative.

Also fixes long-standing doc drift: `/api/v2/limits` and
`/api/v2/limits/history` were promised in the design docs but were
never registered (only `/api/v2/log/api-limits` exists). All
references in `api.md`, `clients.md`, `websocket.md`, and `ux.md`
now redirect to the raw log endpoint, and the imaginary
`LimitsResponse` section is replaced with the real
`ApiLimitsResponse` shape.

Assisted-by: Claude Code (Claude Opus 4.7 (1M context))
