### PR TITLE
fix: surface startup and relay failures instead of swallowing them

### DIFF
--- a/scripts/hook_relay.py
+++ b/scripts/hook_relay.py
@@ -169,8 +169,7 @@ def main() -> None:
         )
         urllib.request.urlopen(req, timeout=2)
     except Exception:
-        if debug:
-            logger.debug("relay failed", exc_info=True)
+        logger.warning("relay failed url=%s", url, exc_info=True)
 
 
 if __name__ == "__main__":

--- a/src/agentpulse/__main__.py
+++ b/src/agentpulse/__main__.py
@@ -85,13 +85,23 @@ def main() -> int:
     _configure_logging(log_file=settings.log_file, log_level=settings.log_level)
     _install_excepthook(logger=logging.getLogger(__name__))
 
-    uvicorn.run(
-        "agentpulse.app:create_app",
-        factory=True,
-        host=settings.host,
-        port=settings.port,
-        log_level=settings.log_level.lower(),
-    )
+    try:
+        uvicorn.run(
+            "agentpulse.app:create_app",
+            factory=True,
+            host=settings.host,
+            port=settings.port,
+            log_level=settings.log_level.lower(),
+        )
+    except Exception as exc:
+        logging.getLogger(__name__).critical(
+            "service failed host=%s port=%d: %s",
+            settings.host,
+            settings.port,
+            exc,
+            exc_info=True,
+        )
+        return EXIT_ERROR
     return EXIT_SUCCESS
 
 

--- a/src/agentpulse/app.py
+++ b/src/agentpulse/app.py
@@ -97,7 +97,15 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         raise
 
     pidfile.set_base_dir(settings.pidfile_dir)
-    pidfile.write_pid(SERVICE_PIDFILE_NAME)
+    try:
+        pidfile.write_pid(SERVICE_PIDFILE_NAME)
+    except OSError:
+        logger.exception(
+            "failed to write pidfile %s",
+            pidfile.pidfile_path(SERVICE_PIDFILE_NAME),
+        )
+        await close_db()
+        raise
     logger.info("wrote pidfile %s", pidfile.pidfile_path(SERVICE_PIDFILE_NAME))
 
     discovery_task = asyncio.create_task(


### PR DESCRIPTION
- hook_relay.py: upgrade POST error logging from debug to warning so
  relay failures appear in production logs without requiring debug mode
- __main__.py: wrap uvicorn.run in try/except so port-in-use and other
  startup errors return EXIT_ERROR instead of misleading supervisors
  with exit 0
- app.py: catch OSError from pidfile.write_pid during lifespan startup
  and close the DB connection before re-raising to prevent resource leak

Review: C0, C1, I3

Assisted-by: Claude Code (Claude Opus 4.6)
