### PR TITLE
fix(v2): correct session and process cost double-counting on resume

### DIFF
--- a/src/agentpulse/api/v2/queries/processes.py
+++ b/src/agentpulse/api/v2/queries/processes.py
@@ -230,7 +230,28 @@ async def _session_cost_baselines(
             (sid, window_start),
         )
         row = await cursor.fetchone()
-        baselines[sid] = float(row["m"]) if row and row["m"] is not None else 0.0
+        if row and row["m"] is not None:
+            baselines[sid] = float(row["m"])
+        else:
+            first_hook = await db.execute(
+                "SELECT event_name FROM claude_log_hooks "
+                "WHERE session_id = ? ORDER BY received_at, id LIMIT 1",
+                (sid,),
+            )
+            fh_row = await first_hook.fetchone()
+            is_resumed = fh_row is not None and fh_row["event_name"] != "SessionStart"
+            if is_resumed:
+                min_cursor = await db.execute(
+                    "SELECT MIN(cost_usd) AS m FROM claude_log_statuslines "
+                    "WHERE session_id = ? AND cost_usd IS NOT NULL",
+                    (sid,),
+                )
+                min_row = await min_cursor.fetchone()
+                baselines[sid] = (
+                    float(min_row["m"]) if min_row and min_row["m"] is not None else 0.0
+                )
+            else:
+                baselines[sid] = 0.0
     return baselines
 
 

--- a/src/agentpulse/api/v2/queries/sessions.py
+++ b/src/agentpulse/api/v2/queries/sessions.py
@@ -207,7 +207,8 @@ async def _derive_session(db: aiosqlite.Connection, *, session_id: str) -> dict 
         earliest_received_at=earliest,
     )
 
-    # ended_at: from a SessionEnd hook for this session (any pid)
+    # ended_at: from a SessionEnd hook, but only if no activity followed it
+    # (a resumed session will have hooks after the SessionEnd)
     cursor = await db.execute(
         """
         SELECT received_at FROM claude_log_hooks
@@ -217,7 +218,16 @@ async def _derive_session(db: aiosqlite.Connection, *, session_id: str) -> dict 
         (session_id,),
     )
     end_row = await cursor.fetchone()
-    ended_at = float(end_row["received_at"]) if end_row else None
+    if end_row:
+        end_ts = float(end_row["received_at"])
+        cursor = await db.execute(
+            "SELECT 1 FROM claude_log_hooks "
+            "WHERE session_id = ? AND received_at > ? LIMIT 1",
+            (session_id, end_ts),
+        )
+        ended_at = None if await cursor.fetchone() else end_ts
+    else:
+        ended_at = None
 
     last_event = (latest_hook or {}).get("event_name")
     last_tool = (latest_hook or {}).get("tool_name")
@@ -313,10 +323,21 @@ async def _session_cost_by_day(
     ``--resume``). Daily delta = MAX(cost_usd that day) - MAX(cost_usd
     through the prior day), computed globally across all PIDs.
     Server local time bucketing matches queries/processes._cost_by_day.
+
+    For resumed sessions (first hook is not SessionStart), the baseline
+    starts at MIN(cost_usd) from the earliest observed day so that
+    inherited cost from prior processes is not attributed to the first
+    observed day.
+
+    When a day's MAX(cost_usd) is lower than the prior day's MAX, the
+    cost counter has reset (new process started fresh rather than
+    inheriting). The day's delta uses MAX - MIN within that day instead
+    of the cross-day running delta.
     """
     cursor = await db.execute(
         """
         SELECT date(received_at, 'unixepoch', 'localtime') AS day,
+               MIN(cost_usd) AS day_min,
                MAX(cost_usd) AS day_max
         FROM claude_log_statuslines
         WHERE session_id = ? AND cost_usd IS NOT NULL
@@ -326,10 +347,36 @@ async def _session_cost_by_day(
         (session_id,),
     )
     by_day: dict[str, float] = {}
-    prev_max = 0.0
-    for r in await cursor.fetchall():
+    rows = list(await cursor.fetchall())
+    if not rows:
+        return by_day
+
+    # Detect resumed sessions: if the earliest hook is not SessionStart,
+    # the session was --resumed and the first statusline carries inherited
+    # cost from prior processes AgentPulse may never have observed.
+    first_hook = await db.execute(
+        "SELECT event_name FROM claude_log_hooks "
+        "WHERE session_id = ? ORDER BY received_at, id LIMIT 1",
+        (session_id,),
+    )
+    first_hook_row = await first_hook.fetchone()
+    is_resumed = (
+        first_hook_row is not None and first_hook_row["event_name"] != "SessionStart"
+    )
+    if is_resumed:
+        prev_max = float(rows[0]["day_min"])
+    else:
+        prev_max = 0.0
+
+    for r in rows:
         day_max = float(r["day_max"]) if r["day_max"] is not None else prev_max
-        by_day[r["day"]] = round(day_max - prev_max, 6)
+        day_min = float(r["day_min"]) if r["day_min"] is not None else prev_max
+        if day_max < prev_max:
+            # Cost counter reset — new process started fresh.
+            delta = day_max - day_min
+        else:
+            delta = day_max - prev_max
+        by_day[r["day"]] = round(delta, 6)
         prev_max = day_max
     return by_day
 

--- a/tests/api/v2/test_pid_reuse.py
+++ b/tests/api/v2/test_pid_reuse.py
@@ -193,12 +193,24 @@ class TestGetProcessesPerInstance:
 
     async def test_cost_usd_is_per_instance(self, db) -> None:
         # Instance 1: cost reaches 5.0. Instance 2: cost reaches 3.0.
-        await _seed_hook(db, session_id="s1", pid=4242, received_at=10.0)
+        await _seed_hook(
+            db,
+            session_id="s1",
+            pid=4242,
+            received_at=10.0,
+            event_name="SessionStart",
+        )
         await _seed_statusline(
             db, session_id="s1", pid=4242, received_at=20.0, cost_usd=5.0
         )
         await _seed_death(db, pid=4242, observed_at=100.0)
-        await _seed_hook(db, session_id="s2", pid=4242, received_at=200.0)
+        await _seed_hook(
+            db,
+            session_id="s2",
+            pid=4242,
+            received_at=200.0,
+            event_name="SessionStart",
+        )
         await _seed_statusline(
             db, session_id="s2", pid=4242, received_at=210.0, cost_usd=3.0
         )
@@ -212,12 +224,24 @@ class TestGetProcessesPerInstance:
     async def test_cost_by_day_is_per_instance(self, db) -> None:
         # Instance 1: $5 on day 1. Instance 2: $3 on day 1 (different process,
         # cumulative-per-process). Each instance's daily delta is its own.
-        await _seed_hook(db, session_id="s1", pid=4242, received_at=10.0)
+        await _seed_hook(
+            db,
+            session_id="s1",
+            pid=4242,
+            received_at=10.0,
+            event_name="SessionStart",
+        )
         await _seed_statusline(
             db, session_id="s1", pid=4242, received_at=20.0, cost_usd=5.0
         )
         await _seed_death(db, pid=4242, observed_at=100.0)
-        await _seed_hook(db, session_id="s2", pid=4242, received_at=200.0)
+        await _seed_hook(
+            db,
+            session_id="s2",
+            pid=4242,
+            received_at=200.0,
+            event_name="SessionStart",
+        )
         await _seed_statusline(
             db, session_id="s2", pid=4242, received_at=210.0, cost_usd=3.0
         )

--- a/tests/api/v2/test_session_cost.py
+++ b/tests/api/v2/test_session_cost.py
@@ -30,10 +30,11 @@ async def _seed_hook(
     received_at: float,
     cwd: str = "/proj",
     source_system: str = "host",
+    event_name: str = "PreToolUse",
 ) -> None:
     payload = {
         "session_id": session_id,
-        "hook_event_name": "PreToolUse",
+        "hook_event_name": event_name,
         "pid": pid,
         "source_system": source_system,
         "cwd": cwd,
@@ -94,7 +95,13 @@ DAY2_START = DAY1_START + 86400.0  # day after
 
 class TestSessionTotalCost:
     async def test_single_process_session(self, db) -> None:
-        await _seed_hook(db, session_id="s1", pid=10, received_at=DAY1_START)
+        await _seed_hook(
+            db,
+            session_id="s1",
+            pid=10,
+            received_at=DAY1_START,
+            event_name="SessionStart",
+        )
         await _seed_statusline(
             db, session_id="s1", pid=10, received_at=DAY1_START + 60, cost_usd=2.5
         )
@@ -106,8 +113,14 @@ class TestSessionTotalCost:
         # Three SDK invocations on the same session. cost_usd is
         # session-cumulative: each new process carries forward the prior
         # total. The session total is the global MAX.
-        for pid, cost in [(10, 5.0), (20, 12.5), (30, 13.75)]:
-            await _seed_hook(db, session_id="s1", pid=pid, received_at=DAY1_START + pid)
+        for i, (pid, cost) in enumerate([(10, 5.0), (20, 12.5), (30, 13.75)]):
+            await _seed_hook(
+                db,
+                session_id="s1",
+                pid=pid,
+                received_at=DAY1_START + pid,
+                event_name="SessionStart" if i == 0 else "PreToolUse",
+            )
             await _seed_statusline(
                 db,
                 session_id="s1",
@@ -122,7 +135,13 @@ class TestSessionTotalCost:
         """Cost is monotonic within a process — only the LAST (max) reading
         counts per process. Multiple statuslines from one process don't
         double-count."""
-        await _seed_hook(db, session_id="s1", pid=10, received_at=DAY1_START)
+        await _seed_hook(
+            db,
+            session_id="s1",
+            pid=10,
+            received_at=DAY1_START,
+            event_name="SessionStart",
+        )
         # Three readings from the same process — only the max matters
         for ts_offset, cost in [(60, 1.0), (120, 3.0), (180, 5.0)]:
             await _seed_statusline(
@@ -136,7 +155,13 @@ class TestSessionTotalCost:
         assert sess["total_cost_usd"] == 5.0  # max(cost), not sum
 
     async def test_no_cost_yields_zero(self, db) -> None:
-        await _seed_hook(db, session_id="s1", pid=10, received_at=DAY1_START)
+        await _seed_hook(
+            db,
+            session_id="s1",
+            pid=10,
+            received_at=DAY1_START,
+            event_name="SessionStart",
+        )
         # No statuslines at all
         sess = await queries.get_session_by_id(db, session_id="s1")
         assert sess["total_cost_usd"] == 0.0
@@ -145,7 +170,13 @@ class TestSessionTotalCost:
 
 class TestSessionCostByDay:
     async def test_single_process_one_day(self, db) -> None:
-        await _seed_hook(db, session_id="s1", pid=10, received_at=DAY1_START)
+        await _seed_hook(
+            db,
+            session_id="s1",
+            pid=10,
+            received_at=DAY1_START,
+            event_name="SessionStart",
+        )
         await _seed_statusline(
             db, session_id="s1", pid=10, received_at=DAY1_START + 60, cost_usd=4.0
         )
@@ -157,7 +188,13 @@ class TestSessionCostByDay:
     async def test_single_process_two_days(self, db) -> None:
         # Day 1: cost reaches 3.0. Day 2: same process continues, reaches 5.0.
         # Daily deltas: D1=3.0, D2=2.0. Sum=5.0 = the process's MAX.
-        await _seed_hook(db, session_id="s1", pid=10, received_at=DAY1_START)
+        await _seed_hook(
+            db,
+            session_id="s1",
+            pid=10,
+            received_at=DAY1_START,
+            event_name="SessionStart",
+        )
         await _seed_statusline(
             db, session_id="s1", pid=10, received_at=DAY1_START + 60, cost_usd=3.0
         )
@@ -174,7 +211,13 @@ class TestSessionCostByDay:
     async def test_multi_process_same_day_cumulative(self, db) -> None:
         # Two processes on the same day. cost_usd is session-cumulative:
         # pid=20 inherits $2 from pid=10, adds $3 of new work → $5.
-        await _seed_hook(db, session_id="s1", pid=10, received_at=DAY1_START)
+        await _seed_hook(
+            db,
+            session_id="s1",
+            pid=10,
+            received_at=DAY1_START,
+            event_name="SessionStart",
+        )
         await _seed_hook(db, session_id="s1", pid=20, received_at=DAY1_START + 5)
         await _seed_statusline(
             db, session_id="s1", pid=10, received_at=DAY1_START + 60, cost_usd=2.0
@@ -190,7 +233,13 @@ class TestSessionCostByDay:
     async def test_multi_process_multi_day(self, db) -> None:
         # Process A: day1 costs $2. Process B resumes on day2, inherits $2,
         # adds $3 of new work → cumulative $5. Day1=$2, Day2=$3. Total=$5.
-        await _seed_hook(db, session_id="s1", pid=10, received_at=DAY1_START)
+        await _seed_hook(
+            db,
+            session_id="s1",
+            pid=10,
+            received_at=DAY1_START,
+            event_name="SessionStart",
+        )
         await _seed_statusline(
             db, session_id="s1", pid=10, received_at=DAY1_START + 60, cost_usd=2.0
         )
@@ -209,7 +258,13 @@ class TestSessionCostByDay:
         """Second process inherits session cost from the first.
         P10 reaches $4, P20 inherits and adds $1.5 → cumulative $5.5.
         """
-        await _seed_hook(db, session_id="s1", pid=10, received_at=DAY1_START)
+        await _seed_hook(
+            db,
+            session_id="s1",
+            pid=10,
+            received_at=DAY1_START,
+            event_name="SessionStart",
+        )
         await _seed_hook(db, session_id="s1", pid=20, received_at=DAY1_START + 30)
         await _seed_statusline(
             db, session_id="s1", pid=10, received_at=DAY1_START + 100, cost_usd=4.0
@@ -233,7 +288,13 @@ class TestPidReuseAggregation:
 
     async def test_total_cost_with_reused_pid(self, db) -> None:
         # Instance 1: pid=10 reaches $7, dies on day 1
-        await _seed_hook(db, session_id="s1", pid=10, received_at=DAY1_START)
+        await _seed_hook(
+            db,
+            session_id="s1",
+            pid=10,
+            received_at=DAY1_START,
+            event_name="SessionStart",
+        )
         await _seed_statusline(
             db, session_id="s1", pid=10, received_at=DAY1_START + 60, cost_usd=7.0
         )
@@ -249,7 +310,13 @@ class TestPidReuseAggregation:
 
     async def test_cost_by_day_with_reused_pid(self, db) -> None:
         # Same scenario — daily deltas: D1=$7, D2=$11-$7=$4
-        await _seed_hook(db, session_id="s1", pid=10, received_at=DAY1_START)
+        await _seed_hook(
+            db,
+            session_id="s1",
+            pid=10,
+            received_at=DAY1_START,
+            event_name="SessionStart",
+        )
         await _seed_statusline(
             db, session_id="s1", pid=10, received_at=DAY1_START + 60, cost_usd=7.0
         )
@@ -273,7 +340,13 @@ class TestResumedSessionCost:
 
     async def test_resumed_session_total_cost(self, db) -> None:
         # Day 1: pid=100 works up to $17.24
-        await _seed_hook(db, session_id="s1", pid=100, received_at=DAY1_START)
+        await _seed_hook(
+            db,
+            session_id="s1",
+            pid=100,
+            received_at=DAY1_START,
+            event_name="SessionStart",
+        )
         await _seed_statusline(
             db, session_id="s1", pid=100, received_at=DAY1_START + 60, cost_usd=17.24
         )
@@ -302,12 +375,93 @@ class TestResumedSessionCost:
         assert sess["cost_by_day"][days[0]] == pytest.approx(17.24)
         assert sess["cost_by_day"][days[1]] == pytest.approx(2.88)
 
+    async def test_resumed_session_no_prior_day_data(self, db) -> None:
+        """When AgentPulse has no data from prior days, inherited cost
+        should not be attributed to the first observed day."""
+        # Only today's data — session was --resumed with inherited cost
+        # that AgentPulse never saw (no prior-day rows in DB).
+        # No SessionStart hook → detected as resumed.
+        await _seed_hook(db, session_id="s1", pid=200, received_at=DAY2_START)
+        await _seed_statusline(
+            db,
+            session_id="s1",
+            pid=200,
+            received_at=DAY2_START + 10,
+            cost_usd=18.83,
+        )
+        await _seed_statusline(
+            db,
+            session_id="s1",
+            pid=200,
+            received_at=DAY2_START + 60,
+            cost_usd=20.12,
+        )
+
+        sess = await queries.get_session_by_id(db, session_id="s1")
+        assert sess["total_cost_usd"] == pytest.approx(20.12)
+        days = sorted(sess["cost_by_day"].keys())
+        assert len(days) == 1
+        # Delta should be 20.12 - 18.83 = 1.29 (today's work only),
+        # not 20.12 (full cumulative from 0).
+        assert sess["cost_by_day"][days[0]] == pytest.approx(1.29)
+
+    async def test_cost_counter_reset_no_negative_delta(self, db) -> None:
+        """When a new process starts with a fresh cost counter (cost_usd
+        drops), the day's delta should be the new counter's range, not a
+        negative cross-counter delta."""
+        # Day 1: pid=68565 accrues $77.84
+        await _seed_hook(
+            db,
+            session_id="s1",
+            pid=68565,
+            received_at=DAY1_START,
+            event_name="SessionStart",
+        )
+        await _seed_statusline(
+            db,
+            session_id="s1",
+            pid=68565,
+            received_at=DAY1_START + 60,
+            cost_usd=77.84,
+        )
+        # Day 2: pid=208349 starts fresh at ~$0, accrues to $2.69
+        await _seed_hook(db, session_id="s1", pid=208349, received_at=DAY2_START)
+        await _seed_statusline(
+            db,
+            session_id="s1",
+            pid=208349,
+            received_at=DAY2_START + 10,
+            cost_usd=0.12,
+        )
+        await _seed_statusline(
+            db,
+            session_id="s1",
+            pid=208349,
+            received_at=DAY2_START + 60,
+            cost_usd=2.69,
+        )
+
+        sess = await queries.get_session_by_id(db, session_id="s1")
+        days = sorted(sess["cost_by_day"].keys())
+        assert len(days) == 2
+        assert sess["cost_by_day"][days[0]] == pytest.approx(77.84)
+        # Day 2 should be 2.69 - 0.12 = 2.57 (new counter range),
+        # NOT 2.69 - 77.84 = -75.15 (negative cross-counter delta)
+        assert sess["cost_by_day"][days[1]] == pytest.approx(2.57)
+        assert sess["cost_by_day"][days[1]] > 0
+
 
 class TestSessionEndpointExposesCost:
     """The values flow through SessionResponse to the /api/v2/sessions endpoint."""
 
     async def test_response_dict_carries_total_and_breakdown(self, db) -> None:
-        await _seed_hook(db, session_id="s1", pid=10, received_at=DAY1_START)
+        await _seed_hook(
+            db,
+            session_id="s1",
+            pid=10,
+            received_at=DAY1_START,
+            event_name="SessionStart",
+        )
         await _seed_statusline(
             db, session_id="s1", pid=10, received_at=DAY1_START + 60, cost_usd=7.0
         )


### PR DESCRIPTION
- Session cost_by_day: detect resumed sessions (first hook is not
  SessionStart) and use MIN(cost_usd) as baseline instead of 0 so
  inherited cost is not attributed to the first observed day
- Session cost_by_day: handle cost counter resets (new process starts
  fresh) by using within-day delta instead of cross-day running delta
  that produced negative values
- Process cost baselines: apply same SessionStart detection when no
  prior rows exist before window_start
- Session ended_at: only set when no hooks exist after the SessionEnd,
  so resumed sessions correctly show as active

Assisted-by: Claude Code (Claude Opus 4.6)
