### PR TITLE
fix(v2): rank working above ready in effective state priority

### DIFF
--- a/docs/design/api.md
+++ b/docs/design/api.md
@@ -532,12 +532,13 @@ Process effective state = highest-priority across the current
 session's state and any active-agent states.
 
 Priority (highest first):
-`permission_required > awaiting_input > ready > working > idle`.
+`permission_required > awaiting_input > working > ready > idle`.
 
-`ready` outranks `working` deliberately: when the main session has
-finished but a background agent is still ticking, the user should
-see "ready" — the main thing they care about is done. The dashboard
-spec is explicit on this and AgentPulse should match.
+`working` outranks `ready`: agent-level `ready` is not
+user-actionable (users interact with the main loop, not individual
+agents), so any active agent should keep the session showing as
+working. The "needs attention" signal is already carried by
+`permission_required` and `awaiting_input`.
 
 ### Notes on individual states
 

--- a/docs/reference/state-transitions.md
+++ b/docs/reference/state-transitions.md
@@ -88,8 +88,8 @@ effective_state = max_priority(main_state, agent_1_state, agent_2_state, ...)
 |----------|-------|---------|
 | 1 (highest) | Permission Required | Something is blocked waiting for approval |
 | 2 | Awaiting Input | Something asked a question |
-| 3 | Ready | Main process finished (no agents blocking) |
-| 4 | Working | Something is actively processing |
+| 3 | Working | Something is actively processing |
+| 4 | Ready | Main process finished (no agents blocking) |
 | 5 | Idle | Nothing happening |
 | 6 (lowest) | Unknown | No hook events received yet |
 

--- a/src/agentpulse/api/v2/state.py
+++ b/src/agentpulse/api/v2/state.py
@@ -4,20 +4,21 @@
 Mirrors docs/reference/state-transitions.md. Differs from v1 in two places:
 
 1. `Stop` maps to `ready` (transient). v1 maps to `idle`.
-2. Priority is `permission_required > awaiting_input > ready > working > idle`.
-   v1 had `working > ready` (legacy mistake — see plan-v2-refactor.md).
+2. Priority is `permission_required > awaiting_input > working > ready > idle`.
+   Agent-level `ready` is not user-actionable — working outranks it so any
+   active agent keeps the session showing as working.
 
 Also handles the synthetic `clear_state` event which v1 didn't have.
 """
 
-# State priority — lower number = higher priority. Matches the v2 ordering
-# in api.md: ready outranks working (main session "done" beats a background
-# agent still ticking).
+# State priority — lower number = higher priority. Working outranks ready
+# because agent-level ready is not user-actionable; any active agent
+# should keep the session showing as working.
 _STATE_PRIORITY: dict[str, int] = {
     "permission_required": 0,
     "awaiting_input": 1,
-    "ready": 2,
-    "working": 3,
+    "working": 2,
+    "ready": 3,
     "idle": 4,
 }
 


### PR DESCRIPTION
Agent-level ready is not user-actionable — users interact with the
main loop, not individual agents. Any active agent should keep the
session showing as working. The "needs attention" signal is already
carried by permission_required and awaiting_input.

Assisted-by: Claude Code (Claude Opus 4.6)
