### PR TITLE
fix(v2): derive session state from root agent, not subagent lifecycle

### DIFF
--- a/src/agentpulse/api/v2/queries/_helpers.py
+++ b/src/agentpulse/api/v2/queries/_helpers.py
@@ -29,6 +29,36 @@ async def latest_hook_for_session(
     return dict(row) if row else None
 
 
+_NON_STATE_EVENTS: frozenset[str] = frozenset(
+    {
+        "Notification",
+        "SessionEnd",
+    }
+)
+
+
+async def latest_root_hook_for_session(
+    db: aiosqlite.Connection, *, session_id: str
+) -> dict | None:
+    """Latest state-producing hook from the root agent (agent_id IS NULL).
+
+    Skips Notification and SessionEnd — events that derive_state maps to
+    None — so the session state reflects the last meaningful root action.
+    """
+    placeholders = ",".join("?" for _ in _NON_STATE_EVENTS)
+    cursor = await db.execute(
+        f"""
+        SELECT * FROM claude_log_hooks
+        WHERE session_id = ? AND agent_id IS NULL
+              AND event_name NOT IN ({placeholders})
+        ORDER BY received_at DESC, id DESC LIMIT 1
+        """,
+        (session_id, *_NON_STATE_EVENTS),
+    )
+    row = await cursor.fetchone()
+    return dict(row) if row else None
+
+
 async def agents_for_session(
     db: aiosqlite.Connection, *, session_id: str
 ) -> list[dict]:

--- a/src/agentpulse/api/v2/queries/processes.py
+++ b/src/agentpulse/api/v2/queries/processes.py
@@ -18,7 +18,7 @@ from agentpulse.api.v2.ids import derive_process_id
 from agentpulse.api.v2.queries._helpers import (
     active_agent_states,
     agents_for_session,
-    latest_hook_for_session,
+    latest_root_hook_for_session,
 )
 from agentpulse.api.v2.queries._instance import (
     _NO_LOWER,
@@ -408,17 +408,17 @@ async def _derive_process(
 
     derived_state: str | None = None
     if current_session_id:
-        # Use the latest hook for the *current session* (not the latest hook
-        # for the process), so a process whose latest activity is on a new
-        # session reflects that session's state.
-        current_session_latest = await latest_hook_for_session(
+        # Use the latest *root* hook (agent_id IS NULL) for the current
+        # session so subagent lifecycle events (SubagentStop) don't mask
+        # the root agent's state.
+        current_session_root = await latest_root_hook_for_session(
             db, session_id=current_session_id
         )
         session_state = None
-        if current_session_latest is not None:
+        if current_session_root is not None:
             session_state = derive_state(
-                current_session_latest["event_name"],
-                tool_name=current_session_latest["tool_name"] or "",
+                current_session_root["event_name"],
+                tool_name=current_session_root["tool_name"] or "",
             )
         agents = await agents_for_session(db, session_id=current_session_id)
         derived_state = compute_effective_state(

--- a/src/agentpulse/api/v2/queries/sessions.py
+++ b/src/agentpulse/api/v2/queries/sessions.py
@@ -13,6 +13,7 @@ from agentpulse.api.v2.queries._helpers import (
     active_agent_states,
     agents_for_session,
     latest_hook_for_session,
+    latest_root_hook_for_session,
 )
 from agentpulse.api.v2.state import compute_effective_state, derive_state
 
@@ -233,10 +234,11 @@ async def _derive_session(db: aiosqlite.Connection, *, session_id: str) -> dict 
     last_tool = (latest_hook or {}).get("tool_name")
     last_event_at = (latest_hook or {}).get("received_at")
 
+    root_hook = await latest_root_hook_for_session(db, session_id=session_id)
     session_state: str | None = None
-    if latest_hook is not None:
+    if root_hook is not None:
         session_state = derive_state(
-            latest_hook["event_name"], tool_name=latest_hook["tool_name"] or ""
+            root_hook["event_name"], tool_name=root_hook["tool_name"] or ""
         )
     agents = await agents_for_session(db, session_id=session_id)
     derived_state = compute_effective_state(session_state, active_agent_states(agents))

--- a/tests/api/v2/test_queries.py
+++ b/tests/api/v2/test_queries.py
@@ -565,3 +565,406 @@ class TestGetSessionById:
             earliest_received_at=100.5,
         )
         assert detail["epochs"][0]["epoch_id"] == expected
+
+
+class TestSessionDerivedState:
+    """derived_state must reflect root agent state, not subagent lifecycle."""
+
+    async def test_subagent_stop_does_not_mask_root_state(self, db) -> None:
+        """When latest hook is SubagentStop but root agent's last event is
+        Stop, session derived_state should be 'ready', not null."""
+        # Root agent works, then stops (ready)
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="PreToolUse",
+            tool_name="Bash",
+            received_at=100.0,
+        )
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="PostToolUse",
+            tool_name="Bash",
+            received_at=110.0,
+        )
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="Stop",
+            tool_name=None,
+            received_at=120.0,
+        )
+        # Subagent starts and stops (latest hook overall)
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="SubagentStart",
+            agent_id="agent-1",
+            received_at=130.0,
+        )
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="SubagentStop",
+            agent_id="agent-1",
+            received_at=140.0,
+        )
+
+        detail = await queries.get_session_by_id(db, session_id="sa")
+        assert detail["derived_state"] == "ready"
+
+    async def test_subagent_stop_with_root_working(self, db) -> None:
+        """Root agent doing tool use, subagent finishes — session is working."""
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="PreToolUse",
+            tool_name="Edit",
+            received_at=100.0,
+        )
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="SubagentStart",
+            agent_id="agent-1",
+            received_at=110.0,
+        )
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="SubagentStop",
+            agent_id="agent-1",
+            received_at=120.0,
+        )
+
+        detail = await queries.get_session_by_id(db, session_id="sa")
+        assert detail["derived_state"] == "working"
+
+    async def test_no_root_hooks_only_subagent(self, db) -> None:
+        """Session with only subagent hooks → derived_state is None."""
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="SubagentStart",
+            agent_id="agent-1",
+            received_at=100.0,
+        )
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="SubagentStop",
+            agent_id="agent-1",
+            received_at=110.0,
+        )
+
+        detail = await queries.get_session_by_id(db, session_id="sa")
+        assert detail["derived_state"] is None
+
+    async def test_active_subagent_contributes_to_state(self, db) -> None:
+        """A running subagent's state feeds into compute_effective_state."""
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="Stop",
+            tool_name=None,
+            received_at=100.0,
+        )
+        # Subagent started but not stopped — still active
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="SubagentStart",
+            agent_id="agent-1",
+            received_at=110.0,
+        )
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="PreToolUse",
+            tool_name="Bash",
+            agent_id="agent-1",
+            received_at=120.0,
+        )
+
+        detail = await queries.get_session_by_id(db, session_id="sa")
+        # Root is "ready" (Stop), active agent is "working" (PreToolUse)
+        # → effective state is "working" (higher priority)
+        assert detail["derived_state"] == "working"
+
+    async def test_multiple_subagents_all_stopped(self, db) -> None:
+        """Multiple finished subagents don't mask root state."""
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="UserPromptSubmit",
+            tool_name=None,
+            received_at=100.0,
+        )
+        for i, t in enumerate([110.0, 120.0, 130.0, 140.0, 150.0, 160.0]):
+            agent = f"agent-{i // 2 + 1}"
+            event = "SubagentStart" if i % 2 == 0 else "SubagentStop"
+            await _seed_hook(
+                db,
+                session_id="sa",
+                pid=10,
+                event_name=event,
+                agent_id=agent,
+                received_at=t,
+            )
+
+        detail = await queries.get_session_by_id(db, session_id="sa")
+        assert detail["derived_state"] == "working"
+
+    async def test_notification_does_not_mask_root_state(self, db) -> None:
+        """Notification events don't produce state — skip to prior Stop."""
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="Stop",
+            tool_name=None,
+            received_at=100.0,
+        )
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="Notification",
+            tool_name=None,
+            received_at=110.0,
+        )
+
+        detail = await queries.get_session_by_id(db, session_id="sa")
+        assert detail["derived_state"] == "ready"
+
+    async def test_notification_plus_subagent_stop(self, db) -> None:
+        """Real-world scenario: Stop → Notification → SubagentStop."""
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="Stop",
+            tool_name=None,
+            received_at=100.0,
+        )
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="Notification",
+            tool_name=None,
+            received_at=110.0,
+        )
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="SubagentStart",
+            agent_id="agent-1",
+            received_at=120.0,
+        )
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="SubagentStop",
+            agent_id="agent-1",
+            received_at=130.0,
+        )
+
+        detail = await queries.get_session_by_id(db, session_id="sa")
+        assert detail["derived_state"] == "ready"
+
+    async def test_multi_cycle_stop_notification_subagent_stop(self, db) -> None:
+        """Reproduces real session 73b9a18e: multiple work→Stop→Notification
+        cycles with SubagentStop events arriving after the last Notification.
+        derived_state must be 'ready' (from the last Stop), not null."""
+        # First work cycle
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="UserPromptSubmit",
+            tool_name=None,
+            received_at=100.0,
+        )
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="PreToolUse",
+            tool_name="Bash",
+            received_at=110.0,
+        )
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="PostToolUse",
+            tool_name="Bash",
+            received_at=120.0,
+        )
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="Stop",
+            tool_name=None,
+            received_at=130.0,
+        )
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="Notification",
+            tool_name=None,
+            received_at=140.0,
+        )
+        # First subagent finishes (was spawned during the work cycle)
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="SubagentStop",
+            agent_id="agent-1",
+            received_at=150.0,
+        )
+        # Second work cycle
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="UserPromptSubmit",
+            tool_name=None,
+            received_at=160.0,
+        )
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="PreToolUse",
+            tool_name="Edit",
+            received_at=170.0,
+        )
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="PostToolUse",
+            tool_name="Edit",
+            received_at=180.0,
+        )
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="Stop",
+            tool_name=None,
+            received_at=190.0,
+        )
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="Notification",
+            tool_name=None,
+            received_at=200.0,
+        )
+        # Second subagent finishes last — absolute latest event
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="SubagentStop",
+            agent_id="agent-2",
+            received_at=210.0,
+        )
+
+        detail = await queries.get_session_by_id(db, session_id="sa")
+        assert detail["last_event"] == "SubagentStop"
+        assert detail["derived_state"] == "ready"
+
+        sessions = await queries.get_sessions(db)
+        assert sessions[0]["derived_state"] == "ready"
+
+        procs = await queries.get_processes(db)
+        assert procs[0]["derived_state"] == "ready"
+
+    async def test_session_list_derived_state(self, db) -> None:
+        """get_sessions (list view) uses root hook for state too."""
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="Stop",
+            tool_name=None,
+            received_at=100.0,
+        )
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="SubagentStart",
+            agent_id="agent-1",
+            received_at=110.0,
+        )
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="SubagentStop",
+            agent_id="agent-1",
+            received_at=120.0,
+        )
+
+        sessions = await queries.get_sessions(db)
+        assert sessions[0]["derived_state"] == "ready"
+
+
+class TestProcessDerivedState:
+    """Process derived_state must also use root hook, not subagent lifecycle."""
+
+    async def test_process_state_ignores_subagent_stop(self, db) -> None:
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="Stop",
+            tool_name=None,
+            received_at=100.0,
+        )
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="SubagentStart",
+            agent_id="agent-1",
+            received_at=110.0,
+        )
+        await _seed_hook(
+            db,
+            session_id="sa",
+            pid=10,
+            event_name="SubagentStop",
+            agent_id="agent-1",
+            received_at=120.0,
+        )
+
+        procs = await queries.get_processes(db)
+        assert len(procs) == 1
+        assert procs[0]["derived_state"] == "ready"


### PR DESCRIPTION
SubagentStop and Notification events were masking the root agent's
state, causing derived_state to be null for active sessions. Session
state now comes from the latest state-producing root hook (agent_id
IS NULL, excluding Notification and SessionEnd). Subagent states
still feed into compute_effective_state via active_agent_states.

Assisted-by: Claude Code (Claude Opus 4.6)
